### PR TITLE
Feature/nex 94/consumer execution

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
   "require": {
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master"
   },
+  "require-dev": {
+    "php-mock/phpmock": "^2.0"
+  },
   "autoload" : {
     "psr-4" : {
       "oat\\taoLtiConsumer\\" : ""

--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'TAO LTI Consumer',
     'description' => 'TAO LTI Consumer extension',
     'license' => 'GPL-2.0',
-    'version' => '0.1.3',
+    'version' => '0.2.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'taoLti' => '>=9.2.1',

--- a/model/delivery/container/LtiDeliveryContainer.php
+++ b/model/delivery/container/LtiDeliveryContainer.php
@@ -59,17 +59,17 @@ class LtiDeliveryContainer extends AbstractContainer
         $consumerKey = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_KEY]);
         $consumerSecret = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_SECRET]);
         $consumerCallback = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_CALLBACK]);
-        var_dump($consumerCallback);
+
         $data = [
             'lti_message_type' => 'basic-lti-launch-request',
             'lti_version' => 'LTI-1p0',
             'resource_link_id' => $execution->getDelivery()->getUri(),
             'user_id' => $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser()->getIdentifier(),
             'roles' => 'Learner',
-            'oauth_callback' => $consumerCallback,
+            'launch_presentation_return_url' => $consumerCallback,
+            'lis_result_sourcedid' => $execution->getIdentifier(),
         ];
         $data = ToolConsumer::addSignature($ltiUrl, $consumerKey, $consumerSecret, $data);
-        var_dump($data);
 
         $container = new LtiExecutionContainer($execution);
         $container->setData('launchUrl', $ltiUrl);

--- a/model/delivery/container/LtiDeliveryContainer.php
+++ b/model/delivery/container/LtiDeliveryContainer.php
@@ -54,17 +54,22 @@ class LtiDeliveryContainer extends AbstractContainer
         $ltiProvider = $providerResource->getPropertiesValues([
             DataStore::PROPERTY_OAUTH_KEY,
             DataStore::PROPERTY_OAUTH_SECRET,
+            DataStore::PROPERTY_OAUTH_CALLBACK,
         ]);
         $consumerKey = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_KEY]);
         $consumerSecret = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_SECRET]);
+        $consumerCallback = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_CALLBACK]);
+        var_dump($consumerCallback);
         $data = [
             'lti_message_type' => 'basic-lti-launch-request',
             'lti_version' => 'LTI-1p0',
             'resource_link_id' => $execution->getDelivery()->getUri(),
             'user_id' => $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser()->getIdentifier(),
-            'roles' => 'Learner'
+            'roles' => 'Learner',
+            'oauth_callback' => $consumerCallback,
         ];
         $data = ToolConsumer::addSignature($ltiUrl, $consumerKey, $consumerSecret, $data);
+        var_dump($data);
 
         $container = new LtiExecutionContainer($execution);
         $container->setData('launchUrl', $ltiUrl);

--- a/model/delivery/container/LtiDeliveryContainer.php
+++ b/model/delivery/container/LtiDeliveryContainer.php
@@ -75,6 +75,7 @@ class LtiDeliveryContainer extends AbstractContainer
         $container = new LtiExecutionContainer($execution);
         $container->setData('launchUrl', $ltiUrl);
         $container->setData('launchParams', $data);
+
         return $container;
     }
 }

--- a/model/delivery/container/LtiExecutionContainer.php
+++ b/model/delivery/container/LtiExecutionContainer.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ */
+
+namespace oat\taoLtiConsumer\model\delivery\container;
+
+use oat\tao\helpers\Template;
+use oat\taoDelivery\model\container\execution\AbstractExecutionContainer;
+
+/**
+ * Class DeliveryClientContainer
+ * @package oat\taoDelivery\helper
+ */
+class LtiExecutionContainer extends AbstractExecutionContainer
+{
+    /**
+     * @inheritDoc
+     */
+    protected $loaderTemplate = 'container/loader.tpl';
+
+    /**
+     * @inheritDoc
+     */
+    protected $contentTemplate = 'container/template.tpl';
+
+    /**
+     * The name of the extension containing the loader template
+     * @var string
+     */
+    protected $templateExtension = 'taoLtiConsumer';
+
+    /**
+     * {@inheritDoc}
+     * @see \oat\taoDelivery\model\container\execution\AbstractExecutionContainer::getHeaderTemplate()
+     */
+    protected function getHeaderTemplate()
+    {
+        return Template::getTemplate($this->loaderTemplate, $this->templateExtension);
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see \oat\taoDelivery\model\container\execution\AbstractExecutionContainer::getBodyTemplate()
+     */
+    protected function getBodyTemplate()
+    {
+        return Template::getTemplate($this->contentTemplate, $this->templateExtension);
+    }
+}

--- a/model/delivery/container/LtiExecutionContainer.php
+++ b/model/delivery/container/LtiExecutionContainer.php
@@ -24,41 +24,24 @@ use oat\taoDelivery\model\container\execution\AbstractExecutionContainer;
 
 /**
  * Class DeliveryClientContainer
- * @package oat\taoDelivery\helper
  */
 class LtiExecutionContainer extends AbstractExecutionContainer
 {
-    /**
-     * @inheritDoc
-     */
-    protected $loaderTemplate = 'container/loader.tpl';
+    const LOADER_TEMPLATE = 'container/loader.tpl';
+    const CONTENT_TEMPLATE = 'container/ltiExecutionContainerForm.tpl';
 
     /**
-     * @inheritDoc
+     * Name of the extension containing the loader template.
      */
-    protected $contentTemplate = 'container/ltiExecutionContainerForm.tpl';
+    const TEMPLATE_EXTENSION = 'taoLtiConsumer';
 
-    /**
-     * The name of the extension containing the loader template
-     * @var string
-     */
-    protected $templateExtension = 'taoLtiConsumer';
-
-    /**
-     * {@inheritDoc}
-     * @see \oat\taoDelivery\model\container\execution\AbstractExecutionContainer::getHeaderTemplate()
-     */
     protected function getHeaderTemplate()
     {
-        return Template::getTemplate($this->loaderTemplate, $this->templateExtension);
+        return Template::getTemplate(self::LOADER_TEMPLATE, self::TEMPLATE_EXTENSION);
     }
 
-    /**
-     * {@inheritDoc}
-     * @see \oat\taoDelivery\model\container\execution\AbstractExecutionContainer::getBodyTemplate()
-     */
     protected function getBodyTemplate()
     {
-        return Template::getTemplate($this->contentTemplate, $this->templateExtension);
+        return Template::getTemplate(self::CONTENT_TEMPLATE, self::TEMPLATE_EXTENSION);
     }
 }

--- a/model/delivery/container/LtiExecutionContainer.php
+++ b/model/delivery/container/LtiExecutionContainer.php
@@ -36,7 +36,7 @@ class LtiExecutionContainer extends AbstractExecutionContainer
     /**
      * @inheritDoc
      */
-    protected $contentTemplate = 'container/template.tpl';
+    protected $contentTemplate = 'container/ltiExecutionContainerForm.tpl';
 
     /**
      * The name of the extension containing the loader template

--- a/model/delivery/container/LtiExecutionContainer.php
+++ b/model/delivery/container/LtiExecutionContainer.php
@@ -14,7 +14,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2016 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
  */
 
 namespace oat\taoLtiConsumer\model\delivery\container;

--- a/model/delivery/factory/LtiDeliveryFactory.php
+++ b/model/delivery/factory/LtiDeliveryFactory.php
@@ -138,7 +138,7 @@ class LtiDeliveryFactory extends ConfigurableService
         /** @var DeliveryContainerRegistry $registry */
         $registry = $this->propagate(DeliveryContainerRegistry::getRegistry());
         return $registry->getDeliveryContainer('lti', [
-            'ltiProvider' => $ltiProvider,
+            'ltiProvider' => $ltiProvider->getUri(),
             'ltiPath' => $ltiPath
         ]);
     }

--- a/model/delivery/factory/LtiDeliveryFactory.php
+++ b/model/delivery/factory/LtiDeliveryFactory.php
@@ -20,6 +20,10 @@
 
 namespace oat\taoLtiConsumer\model\delivery\factory;
 
+use common_exception_InconsistentData as InconsistentDataException;
+use common_report_Report as Report;
+use core_kernel_classes_Resource as RdfResource;
+use core_kernel_classes_Class as RdfClass;
 use oat\generis\model\OntologyRdfs;
 use oat\tao\model\taskQueue\Task\TaskInterface;
 use oat\taoLtiConsumer\model\delivery\task\LtiDeliveryCreationTask;
@@ -36,8 +40,6 @@ use oat\taoDeliveryRdf\model\event\DeliveryCreatedEvent;
  * Class LtiDeliveryFactory
  *
  * A factory to create LTI based delivery, this creation can done in a deferred way
- *
- * @package oat\taoLtiConsumer\model\delivery\factory
  */
 class LtiDeliveryFactory extends ConfigurableService
 {
@@ -46,20 +48,21 @@ class LtiDeliveryFactory extends ConfigurableService
     /**
      * Create a LTI based delivery under $delvieryClass with $provider & $ltiPath
      *
-     * @param \core_kernel_classes_Class $deliveryClass
-     * @param \core_kernel_classes_Resource $ltiProvider
-     * @param $ltiPath
+     * @param RdfClass $deliveryClass
+     * @param RdfResource $ltiProvider
+     * @param string $ltiPath
      * @param string $label
-     * @param \core_kernel_classes_Resource|null $deliveryResource
-     * @return \common_report_Report
-     * @throws \common_exception_InconsistentData
+     * @param RdfResource|null $deliveryResource
+     *
+     * @return Report
+     * @throws InconsistentDataException
      */
     public function create(
-        \core_kernel_classes_Class $deliveryClass,
-        \core_kernel_classes_Resource $ltiProvider,
+        RdfClass $deliveryClass,
+        RdfResource $ltiProvider,
         $ltiPath,
         $label = '',
-        \core_kernel_classes_Resource $deliveryResource = null
+        RdfResource $deliveryResource = null
     ) {
         $this->logInfo(sprintf(
             'Creating LTI delivery with LTI provider "%s" '. 'with LTI test url "%s" under delivery class "%s"',
@@ -78,17 +81,17 @@ class LtiDeliveryFactory extends ConfigurableService
             ContainerRuntime::PROPERTY_CONTAINER => json_encode($container),
         ];
 
-        if (!$deliveryResource instanceof \core_kernel_classes_Resource) {
-            $deliveryResource = $deliveryClass->createInstanceWithProperties($properties);
-        } else {
+        if ($deliveryResource instanceof RdfResource) {
             $deliveryResource->setPropertiesValues($properties);
+        } else {
+            $deliveryResource = $deliveryClass->createInstanceWithProperties($properties);
         }
 
         $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
         $eventManager->trigger(new DeliveryCreatedEvent($deliveryResource->getUri()));
 
-        return new \common_report_Report(
-            \common_report_Report::TYPE_SUCCESS,
+        return new Report(
+            Report::TYPE_SUCCESS,
             __('LTI delivery successfully created.'),
             $deliveryResource
         );
@@ -97,19 +100,20 @@ class LtiDeliveryFactory extends ConfigurableService
     /**
      * Create a task for LTI delivery creation
      *
-     * @param \core_kernel_classes_Class $deliveryClass
-     * @param \core_kernel_classes_Resource $ltiProvider
-     * @param $ltiPath
+     * @param RdfClass $deliveryClass
+     * @param RdfResource $ltiProvider
+     * @param string $ltiPath
      * @param string $label
-     * @param \core_kernel_classes_Resource|null $deliveryResource
+     * @param RdfResource|null $deliveryResource
+     *
      * @return TaskInterface
      */
     public function deferredCreate(
-        \core_kernel_classes_Class $deliveryClass,
-        \core_kernel_classes_Resource $ltiProvider,
+        RdfClass $deliveryClass,
+        RdfResource $ltiProvider,
         $ltiPath,
         $label = '',
-        \core_kernel_classes_Resource $deliveryResource = null
+        RdfResource $deliveryResource = null
     ) {
         $action = new LtiDeliveryCreationTask();
         $parameters = [
@@ -128,12 +132,12 @@ class LtiDeliveryFactory extends ConfigurableService
     /**
      * Retrieve the delivery container associated to LTI
      *
-     * @param \core_kernel_classes_Resource $ltiProvider
+     * @param RdfResource $ltiProvider
      * @param $ltiPath
      * @return string
-     * @throws \common_exception_InconsistentData
+     * @throws InconsistentDataException
      */
-    protected function getLtiDeliveryContainer(\core_kernel_classes_Resource $ltiProvider, $ltiPath)
+    private function getLtiDeliveryContainer(RdfResource $ltiProvider, $ltiPath)
     {
         /** @var DeliveryContainerRegistry $registry */
         $registry = $this->propagate(DeliveryContainerRegistry::getRegistry());

--- a/model/delivery/task/LtiDeliveryCreationTask.php
+++ b/model/delivery/task/LtiDeliveryCreationTask.php
@@ -61,7 +61,7 @@ class LtiDeliveryCreationTask extends AbstractAction implements \JsonSerializabl
         }
 
         $ltiProvider = $this->getResource($params['ltiProvider']);
-        $ltiPath = $params['ltiProvider'];
+        $ltiPath = $params['ltiPath'];
         $label = isset($params['label']) ? $params['label'] : '';
         $deliveryResource = isset($params['deliveryResource']) ? $this->getResource($params['deliveryResource']) : null;
 

--- a/model/delivery/task/LtiDeliveryCreationTask.php
+++ b/model/delivery/task/LtiDeliveryCreationTask.php
@@ -20,12 +20,14 @@
 
 namespace oat\taoLtiConsumer\model\delivery\task;
 
+use core_kernel_classes_Class as RdfClass;
+use common_exception_InconsistentData as InconsistentDataException;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\extension\AbstractAction;
 use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
 use oat\taoLtiConsumer\model\delivery\factory\LtiDeliveryFactory;
 use common_report_Report as Report;
-use common_exception_MissingParameter as MissingParameter;
+use common_exception_MissingParameter as MissingParameterException;
 
 class LtiDeliveryCreationTask extends AbstractAction implements \JsonSerializable
 {
@@ -37,33 +39,26 @@ class LtiDeliveryCreationTask extends AbstractAction implements \JsonSerializabl
      * The only responsability of this task is to parse parameters and forward request to LtiDeliveryFactory
      *
      * @param array $params
-     * @throws \common_exception_MissingParameter
-     * @throws \common_exception_InconsistentData
+     * @throws MissingParameterException
+     * @throws InconsistentDataException
      * @return Report
      */
     public function __invoke($params)
     {
         if (!isset($params['ltiProvider'])) {
-            throw new MissingParameter('Missing parameter `ltiProvider` in ' . self::class);
+            throw new MissingParameterException('ltiProvider', self::class);
         }
 
         if (!isset($params['ltiPath'])) {
-            throw new MissingParameter('Missing parameter `ltiPath` in ' . self::class);
+            throw new MissingParameterException('ltiPath', self::class);
         }
 
-        if (isset($params['deliveryClass'])) {
-            $deliveryClass = $this->getClass($params['deliveryClass']);
-            if (!$deliveryClass->exists()) {
-                $deliveryClass = $this->getClass(DeliveryAssemblyService::CLASS_URI);
-            }
-        } else {
-            $deliveryClass = $this->getClass(DeliveryAssemblyService::CLASS_URI);
-        }
+        $deliveryClass = $this->getDeliveryClass($params);
 
         $ltiProvider = $this->getResource($params['ltiProvider']);
         $ltiPath = $params['ltiPath'];
         $label = isset($params['label']) ? $params['label'] : '';
-        $deliveryResource = isset($params['deliveryResource']) ? $this->getResource($params['deliveryResource']) : null;
+        $deliveryResource = isset($params['deliveryResource'])? $this->getResource($params['deliveryResource']) : null;
 
         /** @var Report $report */
         $report = $this->getLtiDeliveryFactory()->create(
@@ -91,5 +86,22 @@ class LtiDeliveryCreationTask extends AbstractAction implements \JsonSerializabl
     protected function getLtiDeliveryFactory()
     {
         return $this->getServiceLocator()->get(LtiDeliveryFactory::class);
+    }
+
+    /**
+     * @param $params
+     *
+     * @return RdfClass
+     */
+    protected function getDeliveryClass($params)
+    {
+        if (isset($params['deliveryClass'])) {
+            $deliveryClass = $this->getClass($params['deliveryClass']);
+            if ($deliveryClass->exists()) {
+                return $deliveryClass;
+            }
+        }
+
+        return $this->getClass(DeliveryAssemblyService::CLASS_URI);
     }
 }

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -45,6 +45,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '0.1.3');
+        $this->skip('0.1.0', '0.2.0');
     }
 }

--- a/test/unit/model/delivery/container/LtiDeliveryContainerTest.php
+++ b/test/unit/model/delivery/container/LtiDeliveryContainerTest.php
@@ -18,63 +18,135 @@
  *
  */
 
-namespace oat\taoLtiConsumer\model\delivery\container;
+namespace oat\taoLtiConsumer\test\unit\model\delivery\container;
 
-use oat\taoDelivery\model\container\delivery\AbstractContainer;
-use oat\taoDelivery\model\container\execution\ExecutionClientContainer;
-use oat\taoDelivery\model\container\ExecutionContainer;
-use oat\taoDelivery\model\execution\DeliveryExecution;
+use core_kernel_classes_Resource as RdfResource;
 use IMSGlobal\LTI\ToolProvider\ToolConsumer;
+use oat\generis\model\data\Model;
+use oat\generis\test\unit\OntologyMockTest;
 use oat\oatbox\session\SessionService;
-use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\user\User;
 use oat\tao\model\oauth\DataStore;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoLtiConsumer\model\delivery\container\LtiDeliveryContainer;
+use oat\taoLtiConsumer\model\delivery\container\LtiExecutionContainer;
+use phpmock\MockBuilder;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Zend\ServiceManager\ServiceLocatorInterface;
 
-/**
- * Class LtiDeliveryContainer
- *
- * A delivery container to manage LTI based delivery
- *
- * @package oat\taoLtiConsumer\model\delivery\container
- */
-class LtiDeliveryContainer extends AbstractContainer
+class LtiDeliveryContainerTest extends OntologyMockTest
 {
-    use OntologyAwareTrait;
-    /**
-     * Get the execution container to render LTI based delivery
-     *
-     * @param DeliveryExecution $execution
-     * @return ExecutionClientContainer|ExecutionContainer
-     * @throws \common_exception_NotImplemented
-     */
-    public function getExecutionContainer(DeliveryExecution $execution)
+    public function testGetExecutionContainer()
     {
-        // TODO: this has to be covered
-        $params = $this->getRuntimeParams();
-        $providerResource = $this->getResource($params['ltiProvider']);
-        $ltiUrl = $params['ltiPath'];
-        $ltiProvider = $providerResource->getPropertiesValues([
+        $resourceLinkId = 'id of the resource';
+        $identifier = 'delivery identifier';
+        $ltiProviderId = 'lti provider id';
+        $ltiUrl = 'path to lti';
+        $consumerKey = 'consumerKey';
+        $consumerSecret = 'consumerSecret';
+        $consumerCallback = 'consumerCallback';
+        $userId = 'userId';
+        $md5 = 'random-md5';
+
+        $params = [
+            'ltiProvider' => $ltiProviderId,
+            'ltiPath' => $ltiUrl,
+        ];
+        $ltiProvider = [
+            DataStore::PROPERTY_OAUTH_KEY => [$consumerKey],
+            DataStore::PROPERTY_OAUTH_SECRET => [$consumerSecret],
+            DataStore::PROPERTY_OAUTH_CALLBACK => [$consumerCallback],
+        ];
+
+        /** @var RdfResource|MockObject $delivery */
+        $delivery = $this->getMockBuilder(RdfResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getUri'])
+            ->getMock();
+        $delivery->method('getUri')->willReturn($resourceLinkId);
+
+        /** @var DeliveryExecution|MockObject $execution */
+        $execution = $this->getMockBuilder(DeliveryExecution::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getDelivery', 'getIdentifier'])
+            ->getMock();
+        $execution->method('getDelivery')->willReturn($delivery);
+        $execution->method('getIdentifier')->willReturn($identifier);
+
+        /** @var RdfResource|MockObject $providerResource */
+        $providerResource = $this->getMockBuilder(RdfResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getPropertiesValues'])
+            ->getMock();
+        $providerResource->method('getPropertiesValues')->with([
             DataStore::PROPERTY_OAUTH_KEY,
             DataStore::PROPERTY_OAUTH_SECRET,
             DataStore::PROPERTY_OAUTH_CALLBACK,
-        ]);
-        $consumerKey = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_KEY]);
-        $consumerSecret = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_SECRET]);
-        $consumerCallback = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_CALLBACK]);
+        ])->willReturn($ltiProvider);
+
+        /** @var Model|MockObject $providerModel */
+        $providerModel = $this->getMockBuilder(Model::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getResource'])
+            ->getMockForAbstractClass();
+        $providerModel->method('getResource')->with($ltiProviderId)->willReturn($providerResource);
+
+        /** @var User|MockObject $serviceLocator */
+        $user = $this->getMockBuilder(User::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getIdentifier'])
+            ->getMockForAbstractClass();
+        $user->method('getIdentifier')->willReturn($userId);
+
+        /** @var SessionService|MockObject $serviceLocator */
+        $sessionService = $this->getMockBuilder(SessionService::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getCurrentUser'])
+            ->getMock();
+        $sessionService->method('getCurrentUser')->willReturn($user);
+
+        /** @var ServiceLocatorInterface|MockObject $serviceLocator */
+        $serviceLocator = $this->getMockBuilder(ServiceLocatorInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMockForAbstractClass();
+        $serviceLocator->method('get')->with(SessionService::SERVICE_ID)->willReturn($sessionService);
 
         $data = [
             'lti_message_type' => 'basic-lti-launch-request',
             'lti_version' => 'LTI-1p0',
-            'resource_link_id' => $execution->getDelivery()->getUri(),
-            'user_id' => $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser()->getIdentifier(),
+            'resource_link_id' => $resourceLinkId,
+            'user_id' => $userId,
             'roles' => 'Learner',
             'launch_presentation_return_url' => $consumerCallback,
-            'lis_result_sourcedid' => $execution->getIdentifier(),
+            'lis_result_sourcedid' => $identifier,
         ];
+
+        // Mock general scope's md5 function to have a testable signature.
+        $builder = new MockBuilder();
+        $builder->setNamespace('IMSGlobal\LTI\OAuth')
+            ->setName("md5")
+            ->setFunction(
+                function () use ($md5) {
+                    return $md5;
+                }
+            );
+
+        $mock = $builder->build();
+        $mock->enable();
         $data = ToolConsumer::addSignature($ltiUrl, $consumerKey, $consumerSecret, $data);
 
-        $container = new LtiExecutionContainer($execution);
-        $container->setData('launchUrl', $ltiUrl);
-        $container->setData('launchParams', $data);
-        return $container;
+        $subject = new LtiDeliveryContainer();
+
+        $subject->setRuntimeParams($params);
+        $subject->setModel($providerModel);
+        $subject->setServiceLocator($serviceLocator);
+
+        $expected = new LtiExecutionContainer($execution);
+        $expected->setData('launchUrl', $ltiUrl);
+        $expected->setData('launchParams', $data);
+
+        $this->assertEquals($expected, $subject->getExecutionContainer($execution));
+        $mock->disable();
     }
 }

--- a/test/unit/model/delivery/container/LtiDeliveryContainerTest.php
+++ b/test/unit/model/delivery/container/LtiDeliveryContainerTest.php
@@ -33,22 +33,22 @@ use oat\tao\model\oauth\DataStore;
  * Class LtiDeliveryContainer
  *
  * A delivery container to manage LTI based delivery
+ *
+ * @package oat\taoLtiConsumer\model\delivery\container
  */
 class LtiDeliveryContainer extends AbstractContainer
 {
     use OntologyAwareTrait;
-
     /**
      * Get the execution container to render LTI based delivery
      *
      * @param DeliveryExecution $execution
-     *
      * @return ExecutionClientContainer|ExecutionContainer
-     * @throws \common_exception_InvalidArgumentType
-     * @throws \common_exception_NotFound
+     * @throws \common_exception_NotImplemented
      */
     public function getExecutionContainer(DeliveryExecution $execution)
     {
+        // TODO: this has to be covered
         $params = $this->getRuntimeParams();
         $providerResource = $this->getResource($params['ltiProvider']);
         $ltiUrl = $params['ltiPath'];

--- a/test/unit/model/delivery/factory/LtiDeliveryFactoryTest.php
+++ b/test/unit/model/delivery/factory/LtiDeliveryFactoryTest.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ *
+ */
+
+namespace oat\taoLtiConsumer\model\delivery\factory;
+
+use common_ext_Extension as Extension;
+use common_ext_ExtensionsManager as ExtensionsManager;
+use common_report_Report as Report;
+use core_kernel_classes_Class as RdfClass;
+use core_kernel_classes_Resource as RdfResource;
+use oat\generis\model\OntologyRdfs;
+use oat\generis\test\TestCase;
+use oat\oatbox\event\EventManager;
+use oat\oatbox\log\LoggerService;
+use oat\tao\model\taskQueue\QueueDispatcher;
+use oat\taoDeliveryRdf\model\ContainerRuntime;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoDeliveryRdf\model\event\DeliveryCreatedEvent;
+use oat\taoLtiConsumer\model\delivery\container\LtiDeliveryContainer;
+use oat\taoLtiConsumer\model\delivery\task\LtiDeliveryCreationTask;
+use phpmock\Mock;
+use phpmock\MockBuilder;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Psr\Log\LoggerInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+/**
+ * Class LtiDeliveryFactory
+ *
+ * A factory to create LTI based delivery, this creation can done in a deferred way
+ *
+ * @package oat\taoLtiConsumer\model\delivery\factory
+ */
+class LtiDeliveryFactoryTest extends TestCase
+{
+    const FIXED_TIME = 1234567890;
+    const RESOURCE_URI = 'Uri of the resource';
+
+    /** @var Mock */
+    protected $timeMock;
+
+    public function setUp()
+    {
+        $this->timeMock = $this->MockFunction('oat\taoLtiConsumer\model\delivery\factory', "time", self::FIXED_TIME);
+        $this->timeMock->disableAll();
+        $this->timeMock->enable();
+    }
+
+    public function tearDown()
+    {
+        $this->timeMock->disableAll();
+    }
+
+    /**
+     * @param string           $initialLabel
+     * @param string           $finalLabel
+     * @param RdfResource|null $deliveryResource
+     *
+     * @throws \common_exception_InconsistentData
+     * @throws \phpmock\MockEnabledException
+     */
+    public function launchGetLtiDeliveryContainerTest($initialLabel, $finalLabel, RdfResource $deliveryResource = null)
+    {
+        $uri = 'providerUri';
+        $ltiPath = 'some path';
+        $classLabel = 'label of the class';
+        $ltiProviderLabel = 'label of the lti provider';
+
+        /** @var RdfClass|MockObject $deliveryClass */
+        $deliveryClass = $this->getMockBuilder(RdfClass::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getLabel', 'countInstances', 'createInstanceWithProperties'])
+            ->getMock();
+        $deliveryClass->method('getLabel')->willReturn($classLabel);
+        $deliveryClass->method('countInstances')->willReturn(0);
+
+        /** @var RdfResource|MockObject $ltiProvider */
+        $ltiProvider = $this->getMockBuilder(RdfResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getUri', 'getLabel'])
+            ->getMock();
+        $ltiProvider->method('getUri')->willReturn($uri);
+        $ltiProvider->method('getLabel')->willReturn($ltiProviderLabel);
+
+        $container = new LtiDeliveryContainer();
+
+        /** @var Extension|MockObject $extensionManager */
+        $deliveryExtension = $this->getMockBuilder(Extension::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getConfig'])
+            ->getMock();
+        $deliveryExtension->method('getConfig')->with('deliveryContainerRegistry')->willReturn(['lti' => $container]);
+
+        /** @var ExtensionsManager|MockObject $extensionManager */
+        $extensionManager = $this->getMockBuilder(ExtensionsManager::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getExtensionById'])
+            ->getMock();
+        $extensionManager->method('getExtensionById')->with('taoDelivery')->willReturn($deliveryExtension);
+
+        /** @var LoggerInterface|MockObject $logger */
+        $logger = $this->getMockBuilder(LoggerInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['info'])
+            ->getMockForAbstractClass();
+        $logger->expects($this->once())->method('info')->with(sprintf(
+            'Creating LTI delivery with LTI provider "%s" ' . 'with LTI test url "%s" under delivery class "%s"',
+            $ltiProviderLabel, $ltiPath, $classLabel
+        ));
+
+        /** @var EventManager|MockObject $eventManager */
+        $eventManager = $this->getMockBuilder(EventManager::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['trigger'])
+            ->getMock();
+        $eventManager->expects($this->once())->method('trigger')->with($this->callback(
+            function (DeliveryCreatedEvent $event) {
+                return $event->getDeliveryUri() === self::RESOURCE_URI;
+            }
+        ));
+
+        /** @var ServiceLocatorInterface|MockObject $serviceLocator */
+        $serviceLocator = $this->getMockBuilder(ServiceLocatorInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMockForAbstractClass();
+        $serviceLocator->method('get')->willReturnCallback(
+            function ($id) use ($extensionManager, $logger, $eventManager) {
+                switch ($id) {
+                    case ExtensionsManager::SERVICE_ID:
+                        return $extensionManager;
+                    case LoggerService::SERVICE_ID:
+                        return $logger;
+                    case EventManager::SERVICE_ID:
+                        return $eventManager;
+                }
+            }
+        );
+
+        $subject = new LtiDeliveryFactory();
+        $subject->setServiceLocator($serviceLocator);
+
+        $properties = [
+            OntologyRdfs::RDFS_LABEL => $finalLabel,
+            DeliveryAssemblyService::PROPERTY_DELIVERY_TIME => self::FIXED_TIME,
+            ContainerRuntime::PROPERTY_CONTAINER => json_encode([
+                'container' => 'lti',
+                'params' => [
+                    'ltiProvider' => $uri,
+                    'ltiPath' => $ltiPath,
+                ],
+            ]),
+        ];
+
+        if ($deliveryResource instanceof RdfResource) {
+            $deliveryResource->expects($this->once())->method('setPropertiesValues')->with($properties);
+            $expectedResource = $deliveryResource;
+        } else {
+            /** @var RdfResource|MockObject $anotherDeliveryResource */
+            $expectedResource = $this->getMockBuilder(RdfResource::class)
+                ->disableOriginalConstructor()
+                ->setMethods(['getUri'])
+                ->getMock();
+            $expectedResource->method('getUri')->willReturn(self::RESOURCE_URI);
+            $deliveryClass->method('createInstanceWithProperties')->with($properties)->willReturn($expectedResource);
+        }
+
+        $actual = $subject->create($deliveryClass, $ltiProvider, $ltiPath, $initialLabel, $deliveryResource);
+        $this->assertInstanceOf(Report::class, $actual);
+        $this->assertEquals(Report::TYPE_SUCCESS, $actual->getType());
+        $this->assertEquals(__('LTI delivery successfully created.'), $actual->getMessage());
+        $this->assertEquals($expectedResource, $actual->getData());
+    }
+
+    public function testGetLtiDeliveryContainerWithDeliveryAndNoLabel()
+    {
+        /** @var RdfResource|MockObject $deliveryResource */
+        $deliveryResource = $this->getMockBuilder(RdfResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setPropertiesValues', 'getUri'])
+            ->getMock();
+        $deliveryResource->method('getUri')->willReturn(self::RESOURCE_URI);
+
+        $this->launchGetLtiDeliveryContainerTest('', 'LTI delivery 1', $deliveryResource);
+    }
+
+    public function testGetLtiDeliveryContainerWithDeliveryAndLabel()
+    {
+        /** @var RdfResource|MockObject $deliveryResource */
+        $deliveryResource = $this->getMockBuilder(RdfResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['setPropertiesValues', 'getUri'])
+            ->getMock();
+        $deliveryResource->method('getUri')->willReturn(self::RESOURCE_URI);
+
+        $this->launchGetLtiDeliveryContainerTest('deliveryLabel', 'deliveryLabel', $deliveryResource);
+    }
+
+    public function testGetLtiDeliveryContainerWithNoDeliveryAndNoLabel()
+    {
+        $this->launchGetLtiDeliveryContainerTest('', 'LTI delivery 1');
+    }
+
+    public function testGetLtiDeliveryContainerWithNoDeliveryAndLabel()
+    {
+        $this->launchGetLtiDeliveryContainerTest('deliveryLabel', 'deliveryLabel');
+    }
+
+    public function testDeferredCreate()
+    {
+        $label = 'task label';
+        $deliveryClassUri = 'uri of delivery class';
+        $ltiPath = 'some path';
+        $ltiProviderLabel = 'label of the lti provider';
+        $ltiProviderUri = 'providerUri';
+        $resourceUri = 'resource URI';
+
+        /** @var RdfClass|MockObject $deliveryClass */
+        $deliveryClass = $this->getMockBuilder(RdfClass::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getUri'])
+            ->getMock();
+        $deliveryClass->method('getUri')->willReturn($deliveryClassUri);
+
+        /** @var RdfResource|MockObject $ltiProvider */
+        $ltiProvider = $this->getMockBuilder(RdfResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getUri', 'getLabel'])
+            ->getMock();
+        $ltiProvider->method('getUri')->willReturn($ltiProviderUri);
+        $ltiProvider->method('getLabel')->willReturn($ltiProviderLabel);
+
+        /** @var RdfResource|MockObject $deliveryResource */
+        $deliveryResource = $this->getMockBuilder(RdfResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getUri'])
+            ->getMock();
+        $deliveryResource->method('getUri')->willReturn($resourceUri);
+
+        $params = [
+            'deliveryClass' => $deliveryClassUri,
+            'ltiProvider' => $ltiProviderUri,
+            'ltiPath' => $ltiPath,
+            'label' => $label,
+            'deliveryResource' => $resourceUri,
+        ];
+
+        /** @var QueueDispatcher|MockObject $queueDispatcher */
+        $queueDispatcher = $this->getMockBuilder(QueueDispatcher::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['createTask'])
+            ->getMock();
+        $queueDispatcher->method('createTask')->with($this->callback(
+            function ($callable) {
+                return $callable instanceof LtiDeliveryCreationTask;
+            }),
+            $params,
+            __('Publishing of LTI delivery : "%s"', $ltiProviderLabel),
+            null,
+            true
+        )->willReturn(true);
+
+        /** @var ServiceLocatorInterface|MockObject $serviceLocator */
+        $serviceLocator = $this->getMockBuilder(ServiceLocatorInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMockForAbstractClass();
+        $serviceLocator->method('get')->willReturnCallback(
+            function ($id) use ($queueDispatcher) {
+                switch ($id) {
+                    case QueueDispatcher::SERVICE_ID:
+                        return $queueDispatcher;
+                }
+            }
+        );
+
+        $subject = new LtiDeliveryFactory();
+        $subject->setServiceLocator($serviceLocator);
+
+        $this->assertTrue($subject->deferredCreate($deliveryClass, $ltiProvider, $ltiPath, $label, $deliveryResource));
+    }
+
+    /**
+     * Mocks general scope's time function.
+     *
+     * @param string $namespace
+     * @param string $functionName
+     * @param mixed  $value
+     *
+     * @return Mock
+     * @throws \phpmock\MockEnabledException
+     */
+    protected function MockFunction($namespace, $functionName, $value)
+    {
+        $builder = new MockBuilder();
+        $builder->setNamespace($namespace)
+            ->setName($functionName)
+            ->setFunction(
+                function () use ($value) {
+                    return $value;
+                }
+            );
+
+        $mock = $builder->build();
+        $mock->enable();
+
+        return $mock;
+    }
+}

--- a/test/unit/model/delivery/task/LtiDeliveryCreationTaskTest.php
+++ b/test/unit/model/delivery/task/LtiDeliveryCreationTaskTest.php
@@ -1,0 +1,175 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA;
+ *
+ */
+
+namespace oat\taoLtiConsumer\test\unit\model\delivery\task;
+
+use common_exception_MissingParameter as MissingParameterException;
+use common_exception_InconsistentData as InconsistentDataException;
+use common_report_Report as Report;
+use core_kernel_classes_Class as RdfClass;
+use core_kernel_classes_Resource as RdfResource;
+use oat\generis\model\data\Model;
+use oat\generis\test\TestCase;
+use oat\taoDeliveryRdf\model\DeliveryAssemblyService;
+use oat\taoLtiConsumer\model\delivery\factory\LtiDeliveryFactory;
+use oat\taoLtiConsumer\model\delivery\task\LtiDeliveryCreationTask;
+use PHPUnit_Framework_MockObject_MockObject as MockObject;
+use Zend\ServiceManager\ServiceLocatorInterface;
+
+class LtiDeliveryCreationTaskTest extends TestCase
+{
+    /**
+     * @dataProvider paramsToTest
+     *
+     * @param string $deliveryClassName
+     * @param bool   $existingClass
+     * @param string $label
+     * @param string $deliveryResourceId
+     *
+     * @throws MissingParameterException
+     * @throws InconsistentDataException
+     */
+    public function testInvoke($deliveryClassName, $existingClass, $label, $deliveryResourceId)
+    {
+        $ltiProviderId = 'ltiProviderId';
+        $ltiPath = 'ltiPath';
+        $params = [
+            'ltiProvider' => $ltiProviderId,
+            'ltiPath' => $ltiPath,
+        ];
+        if ($deliveryClassName !== '' && $existingClass) {
+            $params['deliveryClass'] = $deliveryClassName;
+        } else {
+            $deliveryClassName = DeliveryAssemblyService::CLASS_URI;
+        }
+        /** @var RdfClass|MockObject $deliveryClass */
+        $deliveryClass = $this->getMockBuilder(RdfClass::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['exists'])
+            ->getMock();
+        $deliveryClass->method('exists')->willReturn($existingClass);
+
+        if ($label !== '') {
+            $params['label'] = $label;
+        }
+        if ($deliveryResourceId !== null) {
+            $params['deliveryResource'] = $deliveryResourceId;
+        }
+
+        /** @var Report|MockObject $report */
+        $report = $this->getMockBuilder(Report::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getType'])
+            ->getMock();
+        $report->method('getType')->willReturn($deliveryResourceId !== null ? Report::TYPE_ERROR : Report::TYPE_SUCCESS);
+
+        /** @var RdfResource|MockObject $providerResource */
+        $ltiProvider = $this->getMockBuilder(RdfResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getPropertiesValues'])
+            ->getMock();
+
+        /** @var RdfResource|MockObject $deliveryResource */
+        $deliveryResource = $this->getMockBuilder(RdfResource::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['delete'])
+            ->getMock();
+
+        /** @var Model|MockObject $providerModel */
+        $providerModel = $this->getMockBuilder(Model::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getResource', 'getClass'])
+            ->getMockForAbstractClass();
+        $providerModel->method('getResource')->willReturnCallback(
+            function ($id) use ($ltiProviderId, $ltiProvider, $deliveryResourceId, $deliveryResource) {
+                switch ($id) {
+                    case $ltiProviderId:
+                        return $ltiProvider;
+                    case $deliveryResourceId:
+                        return $deliveryResource;
+                }
+            }
+        );
+        $providerModel->method('getClass')->with($deliveryClassName)->willReturn($deliveryClass);
+
+        /** @var LtiDeliveryFactory|MockObject $litDeliveryFactory */
+        $litDeliveryFactory = $this->getMockBuilder(LtiDeliveryFactory::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['create'])
+            ->getMock();
+        $litDeliveryFactory->method('create')
+            ->with($deliveryClass, $ltiProvider, $ltiPath, $label, $deliveryResourceId !== null ? $deliveryResource : null)
+            ->willReturn($report);
+
+        /** @var ServiceLocatorInterface|MockObject $serviceLocator */
+        $serviceLocator = $this->getMockBuilder(ServiceLocatorInterface::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['get'])
+            ->getMockForAbstractClass();
+        $serviceLocator->method('get')->with(LtiDeliveryFactory::class)->willReturn($litDeliveryFactory);
+
+        $subject = new LtiDeliveryCreationTask();
+        $subject->setModel($providerModel);
+        $subject->setServiceLocator($serviceLocator);
+
+        $this->assertEquals($report, $subject($params));
+    }
+
+    public function paramsToTest()
+    {
+        return [
+            ['', false, '', null],
+            ['', false, '', 'deliveryResource'],
+            ['', false, 'the label', 'deliveryResource'],
+            ['delivery class', false, 'the label', 'deliveryResource'],
+            ['delivery class', true, 'the label', 'deliveryResource'],
+        ];
+    }
+
+    /**
+     * @dataProvider parametersToTest
+     *
+     * @param array  $params
+     * @param string $missing
+     */
+    public function testInvokeWithMissingParametersThrowsException($params, $missing)
+    {
+        $this->setExpectedException(MissingParameterException::class, 'Expected parameter ' . $missing . ' passed to ' . LtiDeliveryCreationTask::class);
+        $subject = new LtiDeliveryCreationTask();
+        $subject($params);
+    }
+
+    public function parametersToTest()
+    {
+        return [
+            [['ltiProvider' => 0], 'ltiPath'],
+            [['ltiPath' => 0], 'ltiProvider'],
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function testJsonSerialize()
+    {
+        $subject = new LtiDeliveryCreationTask();
+        $this->assertEquals(LtiDeliveryCreationTask::class, $subject->jsonSerialize());
+    }
+}

--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ * Copyright (c) 2019 (original work) Open Assessment Technlogies SA
  *
  */
 

--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -1,4 +1,4 @@
-/**
+/*
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- * 
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ *
  */
 
 /**

--- a/views/build/grunt/bundle.js
+++ b/views/build/grunt/bundle.js
@@ -13,7 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2018 (original work) Open Assessment Technologies SA;
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * 
  */
 
 /**
@@ -31,7 +32,8 @@ module.exports = function(grunt) {
                     outputDir : 'loader',
                     bundles : [{
                         name : 'taoLtiConsumer',
-                        default : true
+                        default : true,
+                        babel: true,
                     }]
                 }
             }

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ * Copyright (c) 2019 (original work) Open Assessment Technlogies SA
  *
  */
 

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -1,4 +1,4 @@
-/**
+/*
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- * 
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ *
  */
 
 module.exports = function(grunt) {

--- a/views/build/grunt/sass.js
+++ b/views/build/grunt/sass.js
@@ -1,3 +1,22 @@
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
+ * 
+ */
+
 module.exports = function(grunt) {
 
     var sass    = grunt.config('sass') || {};

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -1,4 +1,4 @@
-/**
+/*
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- * 
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ *
  */
 
 define([

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ * Copyright (c) 2019 (original work) Open Assessment Technlogies SA
  *
  */
 

--- a/views/js/controller/DeliveryMgmt/wizard.js
+++ b/views/js/controller/DeliveryMgmt/wizard.js
@@ -14,8 +14,9 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
  * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- *
+ * 
  */
+
 define([
     'lodash',
     'jquery',

--- a/views/js/controller/routes.js
+++ b/views/js/controller/routes.js
@@ -1,4 +1,4 @@
-/**
+/*
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- * 
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ *
  */
 
 define({

--- a/views/js/controller/routes.js
+++ b/views/js/controller/routes.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ * Copyright (c) 2019 (original work) Open Assessment Technlogies SA
  *
  */
 

--- a/views/js/ltiConsumerLauncher.js
+++ b/views/js/ltiConsumerLauncher.js
@@ -13,7 +13,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ * Copyright (c) 2019 (original work) Open Assessment Technlogies SA
  *
  */
 

--- a/views/js/ltiConsumerLauncher.js
+++ b/views/js/ltiConsumerLauncher.js
@@ -17,10 +17,12 @@
  * 
  */
 
-define({
-    'DeliveryMgmt': {
-        'actions' : {
-            'wizard' : 'controller/DeliveryMgmt/wizard'
-        }
-    },
-});
+ /**
+ * Form submit handler for ltiExecutionContainerForm.tpl
+ */
+ (() => {
+    const form = document.getElementById('launch-test-form');
+    form.submit();
+ })();
+
+

--- a/views/js/ltiConsumerLauncher.js
+++ b/views/js/ltiConsumerLauncher.js
@@ -1,4 +1,4 @@
-/**
+/*
  * This program is free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License
  * as published by the Free Software Foundation; under version 2
@@ -13,8 +13,8 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA (under the project TAO-PRODUCT);
- * 
+ * Copyright (c) 2014-2019 (original work) Open Assessment Technlogies SA
+ *
  */
 
  /**

--- a/views/templates/container/ltiExecutionContainerForm.tpl
+++ b/views/templates/container/ltiExecutionContainerForm.tpl
@@ -1,3 +1,7 @@
+<?php
+use oat\tao\helpers\Template;
+?>
+
 <h1>Launching test...</h1>
 
 <form action="<?= get_data('launchUrl') ?>" method="post" id="launch-test-form" style="display:none;"">
@@ -9,7 +13,4 @@ foreach (get_data('launchParams') as $key => $value) {
 ?>
     <input type="submit"/>
 </form>
-<script>
-    form = document.getElementById('launch-test-form');
-    form.submit();
-</script>
+<script src="<?= Template::js('ltiConsumerLauncher.js', 'taoLtiConsumer')?>"></script>

--- a/views/templates/container/ltiExecutionContainerForm.tpl
+++ b/views/templates/container/ltiExecutionContainerForm.tpl
@@ -6,9 +6,9 @@ use oat\tao\helpers\Template;
 
 <form action="<?= get_data('launchUrl') ?>" method="post" id="launch-test-form" style="display:none;"">
 <?php 
-foreach (get_data('launchParams') as $key => $value) {
+foreach (get_data('launchParams') as $key => $value):
     echo '<input type="hidden" name="' . $key . '" value="' . $value . '"/>' . PHP_EOL;
-}
+endforeach;
 ?>
     <input type="submit"/>
 </form>

--- a/views/templates/container/template.tpl
+++ b/views/templates/container/template.tpl
@@ -1,4 +1,6 @@
-<form action="<?= get_data('launchUrl') ?>" method="post" id="launch-test-form">
+<h1>Launching test...</h1>
+
+<form action="<?= get_data('launchUrl') ?>" method="post" id="launch-test-form" style="display:none;"">
 <?php 
 foreach (get_data('launchParams') as $key => $value) {
     echo $key.' => '.$value.'</br>';

--- a/views/templates/container/template.tpl
+++ b/views/templates/container/template.tpl
@@ -3,8 +3,7 @@
 <form action="<?= get_data('launchUrl') ?>" method="post" id="launch-test-form" style="display:none;"">
 <?php 
 foreach (get_data('launchParams') as $key => $value) {
-    echo $key.' => '.$value.'</br>';
-    echo '<input type="hidden" name="'.$key.'" value="'.$value.'"/>'.PHP_EOL;
+    echo '<input type="hidden" name="' . $key . '" value="' . $value . '"/>' . PHP_EOL;
 }
 ?>
     <input type="submit"/>

--- a/views/templates/container/template.tpl
+++ b/views/templates/container/template.tpl
@@ -7,3 +7,7 @@ foreach (get_data('launchParams') as $key => $value) {
 ?>
     <input type="submit"/>
 </form>
+<script>
+    form = document.getElementById('launch-test-form');
+    form.submit();
+</script>

--- a/views/templates/container/template.tpl
+++ b/views/templates/container/template.tpl
@@ -1,0 +1,9 @@
+<form action="<?= get_data('launchUrl') ?>" method="post" id="launch-test-form">
+<?php 
+foreach (get_data('launchParams') as $key => $value) {
+    echo $key.' => '.$value.'</br>';
+    echo '<input type="hidden" name="'.$key.'" value="'.$value.'"/>'.PHP_EOL;
+}
+?>
+    <input type="submit"/>
+</form>


### PR DESCRIPTION
This PR still needs some more testing (LtiDeliveryFactory, in progress).
For unit testing review, all tests currently present can be reviewed.

It's functional, but currently, the test is not closed on the provider side at the end indeed...
It's working correctly when using two different instances of tao for LTI providing and LTI consuming.

--------------

To test, you have to install two instances of tao:

1. Provider instance
```
git clone git@github.com:oat-sa/package-tao provider
cd provider
git checkout develop
composer install
cd taoDeliveryRdf
git checkout develop
git pull
cd ..
php tao/scripts/taoInstall.php --db_driver pdo_mysql --db_host localhost --db_name tao_nex94_provider --db_user root --db_pass mysql --module_namespace http://tao.local/mytao.rdf --module_url http://127.0.0.1/oat/NEX-94/provider/ --user_login admin --user_pass admin -e taoCe
cd ..
```

In browser, go to the provider instance login page (e.g. http://127.0.0.1/oat/NEX-94/provider)
Log in as admin.
Go to Extension manager.
Install `ltiDeliveryProvider` extension. This will also install `taoLti` extension.
Go to LTI Consumers.
Create an LTI consumer (note the label, consumer key and secret you provide, leave consumer callback URL blank for the moment).
Go to Tests.
Import a LTI compatible test (for example : taoQtiTest/test/samples/archives/QTI 2.1/basic/basic.zip).
Go to deliveries.
Create a new regular delivery with the imported test.
Copy and note the **launch URL** given when clicking on LTI button in the left menu (e.g. http://127.0.0.1/oat/NEX-94/provider/ltiDeliveryProvider/DeliveryTool/launch/eyJkZWxpdmVyeSI6Imh0dHA6XC9cL3Rhby5sb2NhbFwvbXl0YW8ucmRmI2kxNTYyMjQ3NzM0NTUyMDMxIn0=).

2. Consumer instance
```
git clone git@github.com:oat-sa/package-tao consumer
cd consumer
git checkout develop 
composer require "oat-sa/extension-tao-lti-consumer"
cd taoDeliveryRdf
git checkout develop 
git pull
cd ..
php tao/scripts/taoInstall.php --db_driver pdo_mysql --db_host localhost --db_name tao_nex94_consumer --db_user root --db_pass mysql --module_namespace http://tao.local/mytao.rdf --module_url http://127.0.0.1/oat/NEX-94/consumer/ --user_login admin --user_pass admin -e taoCe,taoLtiConsumer
```

In browser, go to the consumer instance login page (e.g. http://127.0.0.1/oat/NEX-94/consumer)
Log in as admin.
Go to LTI Providers.
Create an LTI provider (note the label. Consumer key and secret are the ones you provided in the creation of the LTI consumer above. Leave consumer callback URL blank for the moment).
Go to deliveries.
Create and publish a new LTI based delivery with the LTI provider you just created.
Provide the launch URL from above.

Add a new test-taker and a new group.
Assign the test taker to the group.
Assign the LTI delivery to the group.

Login as test taker.
You should see a list of deliveries containing the first deliver you created.
Copy the page URL.

Login as admin again.
In the LTI consumer configuration, paste the url to the `consumer callback URL`.

Login as test taker again.
Take the test. At the end, you should return the the delivery list and see:
- one "in progress"
- one "Available"

This is because the test result is not yet returned to the LTI provider, and we allow multiple attempts.
