### PR TITLE
Used hardcoded return url.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master"
   },
   "require-dev": {
-    "php-mock/phpmock": "^2.0"
+    "php-mock/php-mock": "^2.0"
   },
   "autoload" : {
     "psr-4" : {

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,6 @@
   "require": {
     "oat-sa/oatbox-extension-installer": "~1.1||dev-master"
   },
-  "require-dev": {
-    "php-mock/php-mock": "^2.0"
-  },
   "autoload" : {
     "psr-4" : {
       "oat\\taoLtiConsumer\\" : ""

--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'TAO LTI Consumer',
     'description' => 'TAO LTI Consumer extension',
     'license' => 'GPL-2.0',
-    'version' => '0.2.0',
+    'version' => '0.2.1',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'taoLti' => '>=9.2.1',

--- a/model/delivery/container/LtiDeliveryContainer.php
+++ b/model/delivery/container/LtiDeliveryContainer.php
@@ -55,11 +55,10 @@ class LtiDeliveryContainer extends AbstractContainer
         $ltiProvider = $providerResource->getPropertiesValues([
             DataStore::PROPERTY_OAUTH_KEY,
             DataStore::PROPERTY_OAUTH_SECRET,
-            DataStore::PROPERTY_OAUTH_CALLBACK,
         ]);
         $consumerKey = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_KEY]);
         $consumerSecret = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_SECRET]);
-        $consumerCallback = (string)reset($ltiProvider[DataStore::PROPERTY_OAUTH_CALLBACK]);
+        $returnUrl = _url('index', 'DeliveryServer', 'taoDelivery');
 
         $data = [
             'lti_message_type' => 'basic-lti-launch-request',
@@ -67,7 +66,7 @@ class LtiDeliveryContainer extends AbstractContainer
             'resource_link_id' => $execution->getDelivery()->getUri(),
             'user_id' => $this->getServiceLocator()->get(SessionService::SERVICE_ID)->getCurrentUser()->getIdentifier(),
             'roles' => 'Learner',
-            'launch_presentation_return_url' => $consumerCallback,
+            'launch_presentation_return_url' => $returnUrl,
             'lis_result_sourcedid' => $execution->getIdentifier(),
         ];
         $data = ToolConsumer::addSignature($ltiUrl, $consumerKey, $consumerSecret, $data);

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -45,6 +45,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '0.2.0');
+        $this->skip('0.1.0', '0.2.1');
     }
 }


### PR DESCRIPTION
This PR requires https://github.com/oat-sa/generis/pull/655 for the unit testing part.
Fixed the wrong usage of oAuth callback url.
To run the unit tests, you'll need to update composer in order to get php-mock/php-mock.