### PR TITLE
Use the new LTI Provider abstraction.

### DIFF
--- a/manifest.php
+++ b/manifest.php
@@ -25,7 +25,7 @@ return [
     'label' => 'TAO LTI Consumer',
     'description' => 'TAO LTI Consumer extension',
     'license' => 'GPL-2.0',
-    'version' => '0.2.0',
+    'version' => '0.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
         'taoLti' => '>=9.2.1',

--- a/manifest.php
+++ b/manifest.php
@@ -28,7 +28,7 @@ return [
     'version' => '0.3.0',
     'author' => 'Open Assessment Technologies SA',
     'requires' => [
-        'taoLti' => '>=9.2.1',
+        'taoLti' => '>=10.3.0',
         'taoDeliveryRdf' => '>=8.0.1',
     ],
     'acl' => [

--- a/model/delivery/form/LtiWizardForm.php
+++ b/model/delivery/form/LtiWizardForm.php
@@ -21,13 +21,12 @@
 namespace oat\taoLtiConsumer\model\delivery\form;
 
 use common_Exception;
-use oat\generis\model\kernel\persistence\smoothsql\search\ComplexSearchService;
+use core_kernel_classes_Class as RdfClass;
 use oat\taoDeliveryRdf\view\form\WizardForm;
-use oat\taoLti\models\classes\ProviderService;
-use \tao_helpers_form_xhtml_Form as XhtmlForm;
-use \tao_helpers_form_xhtml_TagWrapper as TagWrapper;
-use \tao_helpers_form_FormFactory as FormFactory;
-use \core_kernel_classes_Class as RdfClass;
+use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
+use tao_helpers_form_FormFactory as FormFactory;
+use tao_helpers_form_xhtml_Form as XhtmlForm;
+use tao_helpers_form_xhtml_TagWrapper as TagWrapper;
 
 class LtiWizardForm extends WizardForm
 {
@@ -40,12 +39,12 @@ class LtiWizardForm extends WizardForm
         $this->form = new XhtmlForm('simpleLtiWizard');
 
         $createElt = FormFactory::getElement('create', 'Free');
-        $createElt->setValue('<button class="form-submitter btn-success small" type="button"><span class="icon-publish"></span> ' .__('Publish').'</button>');
+        $createElt->setValue('<button class="form-submitter btn-success small" type="button"><span class="icon-publish"></span> ' . __('Publish') . '</button>');
         $this->form->setDecorators([
             'actions-bottom' => new TagWrapper(['tag' => 'div', 'cssClass' => 'form-toolbar']),
         ]);
-        $this->form->setActions(array(), 'top');
-        $this->form->setActions(array($createElt), 'bottom');
+        $this->form->setActions([], 'top');
+        $this->form->setActions([$createElt], 'bottom');
     }
 
     /**
@@ -65,15 +64,9 @@ class LtiWizardForm extends WizardForm
         $classUriElt->setValue($class->getUri());
         $this->form->addElement($classUriElt);
 
-        /** @var ComplexSearchService $search */
-        $search = $this->getServiceManager()->get(ComplexSearchService::SERVICE_ID);
-        $queryBuilder = $search->query();
-        $query = $search->searchType($queryBuilder , ProviderService::CLASS_URI, true);
-        $queryBuilder->setCriteria($query);
-
-        $count = $search->getGateway()->count($queryBuilder);
-
-        if (0 === $count) {
+        /** @var LtiProviderService $ltiProviderService */
+        $ltiProviderService = $this->getServiceManager()->get(LtiProviderService::SERVICE_ID);
+        if ($ltiProviderService->count() === 0) {
             throw new NoLtiProviderException();
         }
 

--- a/scripts/update/Updater.php
+++ b/scripts/update/Updater.php
@@ -45,6 +45,6 @@ class Updater extends \common_ext_ExtensionUpdater
             $this->setVersion('0.1.0');
         }
 
-        $this->skip('0.1.0', '0.2.0');
+        $this->skip('0.1.0', '0.3.0');
     }
 }


### PR DESCRIPTION
This PR requires https://github.com/oat-sa/extension-tao-lti/pull/191.

The new abstraction allows to store LTI Providers both in RDF storage and in project configuration.
This is using this new abstraction to gather all LTI providers.

Post-merge:
- [ ] create task to cover missing unit tests