### PR TITLE
Allow run external delivery executions with LTI 1.3

### DIFF
--- a/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLtiConsumer\model\Tool\Factory;
+
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\session\SessionService;
+use oat\oatbox\user\User;
+use oat\tao\helpers\UrlHelper;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoLti\models\classes\LtiLaunchData;
+use oat\taoLti\models\classes\LtiProvider\LtiProvider;
+use oat\taoLti\models\classes\Tool\Factory\LtiLaunchCommandFactoryInterface;
+use oat\taoLti\models\classes\Tool\LtiLaunchCommand;
+use oat\taoLti\models\classes\Tool\LtiLaunchCommandInterface;
+
+class Lti1p1DeliveryLaunchCommandFactory extends ConfigurableService implements LtiLaunchCommandFactoryInterface
+{
+    use OntologyAwareTrait;
+
+    public function create(array $config): LtiLaunchCommandInterface
+    {
+        $launchUrl = $config['launchUrl'];
+
+        /** @var LtiProvider $ltiProvider */
+        $ltiProvider = $config['ltiProvider'];
+
+        /** @var DeliveryExecution $execution */
+        $execution = $config['deliveryExecution'];
+
+        /** @var User $user */
+        $user = $this->getServiceLocator()
+            ->get(SessionService::SERVICE_ID)
+            ->getCurrentUser();
+
+        $urlHelper = $this->getUrlHelper();
+        $returnUrl = $urlHelper->buildUrl(
+            'index',
+            'DeliveryServer',
+            'taoDelivery'
+        );
+        $outcomeServiceUrl = $urlHelper->buildUrl(
+            'manageResults',
+            'ResultController',
+            'taoLtiConsumer'
+        );
+
+        return new LtiLaunchCommand(
+            $ltiProvider,
+            [
+                'Learner'
+            ],
+            [
+                LtiLaunchData::LTI_MESSAGE_TYPE => 'basic-lti-launch-request',
+                LtiLaunchData::RESOURCE_LINK_ID => $execution->getIdentifier(),
+                LtiLaunchData::LAUNCH_PRESENTATION_RETURN_URL => $returnUrl,
+                LtiLaunchData::LIS_RESULT_SOURCEDID => $execution->getIdentifier(),
+                LtiLaunchData::LIS_OUTCOME_SERVICE_URL => $outcomeServiceUrl,
+            ],
+            $user,
+            null,
+            $launchUrl
+        );
+    }
+
+    private function getUrlHelper(): UrlHelper
+    {
+        return $this->getServiceLocator()->get(UrlHelper::class);
+    }
+}

--- a/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
@@ -25,7 +25,6 @@ namespace oat\taoLtiConsumer\model\Tool\Factory;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
-use oat\oatbox\user\User;
 use oat\tao\helpers\UrlHelper;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoLti\models\classes\LtiLaunchData;
@@ -48,9 +47,7 @@ class Lti1p1DeliveryLaunchCommandFactory extends ConfigurableService implements 
         /** @var DeliveryExecution $execution */
         $execution = $config['deliveryExecution'];
 
-        /** @var User $user */
-        $user = $this->getServiceLocator()
-            ->get(SessionService::SERVICE_ID)
+        $user = $this->getSessionService()
             ->getCurrentUser();
 
         $urlHelper = $this->getUrlHelper();
@@ -87,5 +84,11 @@ class Lti1p1DeliveryLaunchCommandFactory extends ConfigurableService implements 
     private function getUrlHelper(): UrlHelper
     {
         return $this->getServiceLocator()->get(UrlHelper::class);
+    }
+
+    private function getSessionService(): SessionService
+    {
+        return $this->getServiceLocator()
+            ->get(SessionService::SERVICE_ID);
     }
 }

--- a/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
@@ -51,11 +51,13 @@ class Lti1p1DeliveryLaunchCommandFactory extends ConfigurableService implements 
             ->getCurrentUser();
 
         $urlHelper = $this->getUrlHelper();
+
         $returnUrl = $urlHelper->buildUrl(
             'index',
             'DeliveryServer',
             'taoDelivery'
         );
+
         $outcomeServiceUrl = $urlHelper->buildUrl(
             'manageResults',
             'ResultController',

--- a/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
@@ -77,6 +77,7 @@ class Lti1p1DeliveryLaunchCommandFactory extends ConfigurableService implements 
                 LtiLaunchData::LIS_RESULT_SOURCEDID => $execution->getIdentifier(),
                 LtiLaunchData::LIS_OUTCOME_SERVICE_URL => $outcomeServiceUrl,
             ],
+            $execution->getIdentifier(),
             $user,
             null,
             $launchUrl

--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2019 (original work) Open Assessment Technologies SA
+ *
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLtiConsumer\model\Tool\Factory;
+
+use oat\generis\model\OntologyAwareTrait;
+use OAT\Library\Lti1p3Core\Message\Claim\ContextClaim;
+use oat\oatbox\service\ConfigurableService;
+use oat\oatbox\session\SessionService;
+use oat\oatbox\user\User;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoLti\models\classes\LtiProvider\LtiProvider;
+use oat\taoLti\models\classes\Tool\Factory\LtiLaunchCommandFactoryInterface;
+use oat\taoLti\models\classes\Tool\LtiLaunchCommand;
+use oat\taoLti\models\classes\Tool\LtiLaunchCommandInterface;
+
+class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements LtiLaunchCommandFactoryInterface
+{
+    use OntologyAwareTrait;
+
+    public function create(array $config): LtiLaunchCommandInterface
+    {
+        $launchUrl = $config['launchUrl'];
+
+        /** @var LtiProvider $ltiProvider */
+        $ltiProvider = $config['ltiProvider'];
+
+        /** @var DeliveryExecution $execution */
+        $execution = $config['deliveryExecution'];
+
+        /** @var User $user */
+        $user = $this->getServiceLocator()
+            ->get(SessionService::SERVICE_ID)
+            ->getCurrentUser();
+
+        #
+        # @TODO Check with Delivery Team what are the necessary, claims, roles, etc...
+        #
+        return new LtiLaunchCommand(
+            $ltiProvider,
+            [
+                'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'
+            ],
+            [
+                new ContextClaim('contextId'),
+                'delivery' => $execution->getIdentifier()
+            ],
+            $user,
+            $user->getIdentifier(),
+            $launchUrl
+        );
+    }
+}

--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -25,7 +25,6 @@ namespace oat\taoLtiConsumer\model\Tool\Factory;
 use oat\generis\model\OntologyAwareTrait;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
-use oat\oatbox\user\User;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLti\models\classes\Tool\Factory\LtiLaunchCommandFactoryInterface;
@@ -46,23 +45,31 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
         /** @var DeliveryExecution $execution */
         $execution = $config['deliveryExecution'];
 
-        /** @var User $user */
-        $user = $this->getServiceLocator()
-            ->get(SessionService::SERVICE_ID)
+        #
+        # @TODO Check with Deliver why now we do not use TAO Delivery execution URI
+        #
+        $resourceIdentifier = $execution->getIdentifier();
+
+        $user = $this->getSessionService()
             ->getCurrentUser();
 
         return new LtiLaunchCommand(
             $ltiProvider,
             [
-                'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'
+                'Learner'
             ],
             [
                 'deliveryExecutionId' => $execution->getIdentifier()
             ],
-            $execution->getIdentifier(),
+            $resourceIdentifier,
             $user,
             $user->getIdentifier(),
             $launchUrl
         );
+    }
+
+    private function getSessionService(): SessionService
+    {
+        return $this->getServiceLocator()->get(SessionService::SERVICE_ID);
     }
 }

--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -65,6 +65,7 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
                 new ContextClaim('contextId'),
                 'delivery' => $execution->getIdentifier()
             ],
+            $execution->getIdentifier(),
             $user,
             $user->getIdentifier(),
             $launchUrl

--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -15,8 +15,7 @@
  * along with this program; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  *
- * Copyright (c) 2019 (original work) Open Assessment Technologies SA
- *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
  */
 
 declare(strict_types=1);
@@ -24,7 +23,6 @@ declare(strict_types=1);
 namespace oat\taoLtiConsumer\model\Tool\Factory;
 
 use oat\generis\model\OntologyAwareTrait;
-use OAT\Library\Lti1p3Core\Message\Claim\ContextClaim;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\User;
@@ -53,17 +51,13 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
             ->get(SessionService::SERVICE_ID)
             ->getCurrentUser();
 
-        #
-        # @TODO Check with Delivery Team what are the necessary, claims, roles, etc...
-        #
         return new LtiLaunchCommand(
             $ltiProvider,
             [
                 'http://purl.imsglobal.org/vocab/lis/v2/membership#Learner'
             ],
             [
-                new ContextClaim('contextId'),
-                'delivery' => $execution->getIdentifier()
+                'deliveryExecutionId' => $execution->getIdentifier()
             ],
             $execution->getIdentifier(),
             $user,

--- a/model/Tool/Factory/LtiDeliveryLaunchCommandFactoryProxy.php
+++ b/model/Tool/Factory/LtiDeliveryLaunchCommandFactoryProxy.php
@@ -1,0 +1,66 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLtiConsumer\model\Tool\Factory;
+
+use LogicException;
+use oat\generis\model\OntologyAwareTrait;
+use oat\oatbox\service\ConfigurableService;
+use oat\taoLti\models\classes\LtiProvider\LtiProvider;
+use oat\taoLti\models\classes\Tool\Factory\LtiLaunchCommandFactoryInterface;
+use oat\taoLti\models\classes\Tool\LtiLaunchCommandInterface;
+
+class LtiDeliveryLaunchCommandFactoryProxy extends ConfigurableService implements LtiLaunchCommandFactoryInterface
+{
+    use OntologyAwareTrait;
+
+    public function create(array $config): LtiLaunchCommandInterface
+    {
+        /** @var LtiProvider $ltiProvider */
+        $ltiProvider = $config['ltiProvider'];
+
+        if ($ltiProvider->getLtiVersion() === '1.1') {
+            return $this->getLti1p1LaunchCommandFactory()->create($config);
+        }
+
+        if ($ltiProvider->getLtiVersion() === '1.3') {
+            return $this->getLti1p3LaunchCommandFactory()->create($config);
+        }
+
+        throw new LogicException(
+            sprintf(
+                'LTI version %s is not supported',
+                $ltiProvider->getLtiVersion()
+            )
+        );
+    }
+
+    private function getLti1p1LaunchCommandFactory(): LtiLaunchCommandFactoryInterface
+    {
+        return $this->getServiceLocator()->get(Lti1p1DeliveryLaunchCommandFactory::class);
+    }
+
+    private function getLti1p3LaunchCommandFactory(): LtiLaunchCommandFactoryInterface
+    {
+        return $this->getServiceLocator()->get(Lti1p3DeliveryLaunchCommandFactory::class);
+    }
+}

--- a/test/unit/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactoryTest.php
+++ b/test/unit/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactoryTest.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; under version 2
+ *  of the License (non-upgradable).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ */
+
+namespace oat\taoLtiConsumer\test\unit\model\Tool\Factory;
+
+use oat\generis\test\TestCase;
+use oat\oatbox\session\SessionService;
+use oat\oatbox\user\User;
+use oat\tao\helpers\UrlHelper;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoLti\models\classes\LtiLaunchData;
+use oat\taoLti\models\classes\LtiProvider\LtiProvider;
+use oat\taoLti\models\classes\Tool\LtiLaunchCommand;
+use oat\taoLtiConsumer\model\Tool\Factory\Lti1p1DeliveryLaunchCommandFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class Lti1p1DeliveryLaunchCommandFactoryTest extends TestCase
+{
+    /** @var SessionService|MockObject */
+    private $sessionService;
+
+    /** @var UrlHelper|MockObject */
+    private $urlHelper;
+
+    /** @var Lti1p1DeliveryLaunchCommandFactory */
+    private $subject;
+
+    public function setUp(): void
+    {
+        $this->sessionService = $this->createMock(SessionService::class);
+        $this->urlHelper = $this->createMock(UrlHelper::class);
+        $this->subject = new Lti1p1DeliveryLaunchCommandFactory();
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    SessionService::SERVICE_ID => $this->sessionService,
+                    UrlHelper::class => $this->urlHelper,
+                ]
+            )
+        );
+    }
+
+    public function testCreate(): void
+    {
+        $execution = $this->expectExecution();
+        $ltiProvider = $this->createMock(LtiProvider::class);
+        $user = $this->expectUser();
+
+        $this->urlHelper
+            ->method('buildUrl')
+            ->willReturnOnConsecutiveCalls(
+                'returnUrl',
+                'outcomeServiceUrl'
+            );
+
+        $expectedCommand = new LtiLaunchCommand(
+            $ltiProvider,
+            [
+                'Learner'
+            ],
+            [
+                LtiLaunchData::LTI_MESSAGE_TYPE => 'basic-lti-launch-request',
+                LtiLaunchData::RESOURCE_LINK_ID => 'deliveryExecutionIdentifier',
+                LtiLaunchData::LAUNCH_PRESENTATION_RETURN_URL => 'returnUrl',
+                LtiLaunchData::LIS_RESULT_SOURCEDID => 'deliveryExecutionIdentifier',
+                LtiLaunchData::LIS_OUTCOME_SERVICE_URL => 'outcomeServiceUrl',
+            ],
+            'deliveryExecutionIdentifier',
+            $user,
+            null,
+            'launchUrl'
+        );
+
+        $config = [
+            'launchUrl' => 'launchUrl',
+            'ltiProvider' => $ltiProvider,
+            'deliveryExecution' => $execution
+        ];
+
+        $this->assertEquals($expectedCommand, $this->subject->create($config));
+    }
+
+    private function expectUser(): User
+    {
+        $user = $this->createMock(User::class);
+
+        $user->method('getIdentifier')
+            ->willReturn('userIdentifier');
+
+        $this->sessionService
+            ->method('getCurrentUser')
+            ->willReturn($user);
+
+        return $user;
+    }
+
+    private function expectExecution(): DeliveryExecution
+    {
+        $execution = $this->createMock(DeliveryExecution::class);
+
+        $execution->method('getIdentifier')
+            ->willReturn('deliveryExecutionIdentifier');
+
+        return $execution;
+    }
+}

--- a/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
+++ b/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; under version 2
+ *  of the License (non-upgradable).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ */
+
+namespace oat\taoLtiConsumer\test\unit\model\Tool\Factory;
+
+use oat\generis\test\TestCase;
+use oat\oatbox\session\SessionService;
+use oat\oatbox\user\User;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoLti\models\classes\LtiProvider\LtiProvider;
+use oat\taoLti\models\classes\Tool\LtiLaunchCommand;
+use oat\taoLtiConsumer\model\Tool\Factory\Lti1p3DeliveryLaunchCommandFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class Lti1p3DeliveryLaunchCommandFactoryTest extends TestCase
+{
+    /** @var SessionService|MockObject */
+    private $sessionService;
+
+    /** @var Lti1p3DeliveryLaunchCommandFactory */
+    private $subject;
+
+    public function setUp(): void
+    {
+        $this->sessionService = $this->createMock(SessionService::class);
+        $this->subject = new Lti1p3DeliveryLaunchCommandFactory();
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    SessionService::SERVICE_ID => $this->sessionService
+                ]
+            )
+        );
+    }
+
+    public function testCreate(): void
+    {
+        $execution = $this->createMock(DeliveryExecution::class);
+
+        $execution->method('getIdentifier')
+            ->willReturn('deliveryExecutionIdentifier');
+
+        $ltiProvider = $this->createMock(LtiProvider::class);
+
+        $user = $this->createMock(User::class);
+
+        $user->method('getIdentifier')
+            ->willReturn('userIdentifier');
+
+        $this->sessionService
+            ->method('getCurrentUser')
+            ->willReturn($user);
+
+        $expectedCommand = new LtiLaunchCommand(
+            $ltiProvider,
+            [
+                'Learner'
+            ],
+            [
+                'deliveryExecutionId' => 'deliveryExecutionIdentifier'
+            ],
+            'deliveryExecutionIdentifier',
+            $user,
+            'userIdentifier',
+            'launchUrl'
+        );
+
+        $config = [
+            'launchUrl' => 'launchUrl',
+            'ltiProvider' => $ltiProvider,
+            'deliveryExecution' => $execution
+        ];
+
+        $this->assertEquals($expectedCommand, $this->subject->create($config));
+    }
+}

--- a/test/unit/model/Tool/Factory/LtiDeliveryLaunchCommandFactoryProxyTest.php
+++ b/test/unit/model/Tool/Factory/LtiDeliveryLaunchCommandFactoryProxyTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ *  This program is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU General Public License
+ *  as published by the Free Software Foundation; under version 2
+ *  of the License (non-upgradable).
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ *  Copyright (c) 2020 (original work) Open Assessment Technologies SA
+ */
+
+namespace oat\taoLtiConsumer\test\unit\model\Tool\Factory;
+
+use LogicException;
+use oat\generis\test\TestCase;
+use oat\taoLti\models\classes\LtiProvider\LtiProvider;
+use oat\taoLti\models\classes\Tool\LtiLaunchCommandInterface;
+use oat\taoLtiConsumer\model\Tool\Factory\Lti1p1DeliveryLaunchCommandFactory;
+use oat\taoLtiConsumer\model\Tool\Factory\Lti1p3DeliveryLaunchCommandFactory;
+use oat\taoLtiConsumer\model\Tool\Factory\LtiDeliveryLaunchCommandFactoryProxy;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class LtiDeliveryLaunchCommandFactoryProxyTest extends TestCase
+{
+    /** @var Lti1p1DeliveryLaunchCommandFactory|MockObject */
+    private $lti1p1DeliveryLaunchCommandFactory;
+
+    /** @var Lti1p3DeliveryLaunchCommandFactory|MockObject */
+    private $lti1p3DeliveryLaunchCommandFactory;
+
+    /** @var LtiDeliveryLaunchCommandFactoryProxy */
+    private $subject;
+
+    public function setUp(): void
+    {
+        $this->lti1p1DeliveryLaunchCommandFactory = $this->createMock(Lti1p1DeliveryLaunchCommandFactory::class);
+        $this->lti1p3DeliveryLaunchCommandFactory = $this->createMock(Lti1p3DeliveryLaunchCommandFactory::class);
+        $this->subject = new LtiDeliveryLaunchCommandFactoryProxy();
+        $this->subject->setServiceLocator(
+            $this->getServiceLocatorMock(
+                [
+                    Lti1p1DeliveryLaunchCommandFactory::class => $this->lti1p1DeliveryLaunchCommandFactory,
+                    Lti1p3DeliveryLaunchCommandFactory::class => $this->lti1p3DeliveryLaunchCommandFactory
+                ]
+            )
+        );
+    }
+
+    public function testCreateLti1p1Command(): void
+    {
+        $expectedCommand = $this->createMock(LtiLaunchCommandInterface::class);
+
+        $ltiProvider = $this->createMock(LtiProvider::class);
+
+        $ltiProvider->method('getLtiVersion')
+            ->willReturn('1.1');
+
+        $this->lti1p1DeliveryLaunchCommandFactory
+            ->method('create')
+            ->willReturn($expectedCommand);
+
+        $this->assertEquals(
+            $expectedCommand,
+            $this->subject->create(
+                [
+                    'ltiProvider' => $ltiProvider,
+                ]
+            )
+        );
+    }
+
+    public function testCreateLti1p3Command(): void
+    {
+        $expectedCommand = $this->createMock(LtiLaunchCommandInterface::class);
+
+        $ltiProvider = $this->createMock(LtiProvider::class);
+
+        $ltiProvider->method('getLtiVersion')
+            ->willReturn('1.3');
+
+        $this->lti1p3DeliveryLaunchCommandFactory
+            ->method('create')
+            ->willReturn($expectedCommand);
+
+        $this->assertEquals(
+            $expectedCommand,
+            $this->subject->create(
+                [
+                    'ltiProvider' => $ltiProvider,
+                ]
+            )
+        );
+    }
+
+    public function testCreateUnsupportedLtiVersionWillThrowException(): void
+    {
+        $ltiProvider = $this->createMock(LtiProvider::class);
+
+        $ltiProvider->method('getLtiVersion')
+            ->willReturn('1.4');
+
+        $this->expectExceptionMessage(LogicException::class);
+        $this->expectExceptionMessage('LTI version 1.4 is not supported');
+
+        $this->subject->create(
+            [
+                'ltiProvider' => $ltiProvider,
+            ]
+        );
+    }
+}


### PR DESCRIPTION
https://oat-sa.atlassian.net/browse/NEX-1539

Allow run external delivery executions with LTI 1.3

== ATTENTION ==

- This PR does not consider yet the resource_link_id retrieval part. The scope of the task was reduced and the resource_link_id retrieval will be done on https://oat-sa.atlassian.net/browse/NEX-1633
- We are currently using internal execution ID as resource_link_id (as it was for LTI 1.1).
- Test breaks because taoLti was not merged to develop. Locally it passes.