### PR TITLE
Make OIDC mandatory

### DIFF
--- a/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactory.php
@@ -78,7 +78,7 @@ class Lti1p1DeliveryLaunchCommandFactory extends ConfigurableService implements 
             ],
             $execution->getIdentifier(),
             $user,
-            null,
+            $user->getIdentifier(),
             $launchUrl
         );
     }

--- a/test/unit/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactoryTest.php
+++ b/test/unit/model/Tool/Factory/Lti1p1DeliveryLaunchCommandFactoryTest.php
@@ -83,7 +83,7 @@ class Lti1p1DeliveryLaunchCommandFactoryTest extends TestCase
             ],
             'deliveryExecutionIdentifier',
             $user,
-            null,
+            'userIdentifier',
             'launchUrl'
         );
 


### PR DESCRIPTION
Make OIDC mandatory:

https://oat-sa.atlassian.net/browse/NEX-1858

P.s Tests are broken because of missing interface and build limitations of https://github.com/oat-sa/tao-dependency-resolver