### PR TITLE
Feature TR-2284 - submit a basic outcome claim when requesting an LTI 1.3 tool

### DIFF
--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -23,10 +23,10 @@ declare(strict_types=1);
 namespace oat\taoLtiConsumer\model\Tool\Factory;
 
 use oat\generis\model\OntologyAwareTrait;
+use OAT\Library\Lti1p3Core\Message\Payload\Claim\BasicOutcomeClaim;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
 use oat\taoDelivery\model\execution\DeliveryExecution;
-use oat\taoLti\models\classes\LtiLaunchData;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLti\models\classes\Tool\Factory\LtiLaunchCommandFactoryInterface;
 use oat\taoLti\models\classes\Tool\LtiLaunchCommand;
@@ -60,8 +60,10 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
                 'Learner'
             ],
             [
-                LtiLaunchData::LIS_RESULT_SOURCEDID => $execution->getIdentifier(),
-                LtiLaunchData::LIS_OUTCOME_SERVICE_URL => $this->getLisOutcomeServiceUrlFactory()->create(),
+                new BasicOutcomeClaim(
+                    $execution->getIdentifier(),
+                    $this->getLisOutcomeServiceUrlFactory()->create()
+                ),
             ],
             $resourceIdentifier,
             $user,

--- a/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
+++ b/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
@@ -20,10 +20,10 @@
 namespace oat\taoLtiConsumer\test\unit\model\Tool\Factory;
 
 use oat\generis\test\TestCase;
+use OAT\Library\Lti1p3Core\Message\Payload\Claim\BasicOutcomeClaim;
 use oat\oatbox\session\SessionService;
 use oat\oatbox\user\User;
 use oat\taoDelivery\model\execution\DeliveryExecution;
-use oat\taoLti\models\classes\LtiLaunchData;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLti\models\classes\Tool\LtiLaunchCommand;
 use oat\taoLtiConsumer\model\Tool\Factory\LisOutcomeServiceUrlFactory;
@@ -102,8 +102,10 @@ class Lti1p3DeliveryLaunchCommandFactoryTest extends TestCase
                 'Learner'
             ],
             [
-                LtiLaunchData::LIS_RESULT_SOURCEDID => 'deliveryExecutionIdentifier',
-                LtiLaunchData::LIS_OUTCOME_SERVICE_URL => 'outcomeServiceUrl',
+                new BasicOutcomeClaim(
+                    'deliveryExecutionIdentifier',
+                    'outcomeServiceUrl'
+                ),
             ],
             'deliveryExecutionIdentifier',
             $user,


### PR DESCRIPTION
feat: submit a proper `BasicOutcome` claim when sending an LTI platform-originating message

⚠️ Required for https://github.com/oat-sa/tao-deliver-be/pull/708