### PR TITLE
TR-3705 use DI container to initialize replace result parsers

### DIFF
--- a/controller/ResultController.php
+++ b/controller/ResultController.php
@@ -190,6 +190,6 @@ class ResultController extends tao_actions_CommonModule
 
     private function getLtiReplaceResultParser(): ReplaceResultParserInterface
     {
-        return $this->getServiceLocator()->get(LtiReplaceResultParserProxy::class);
+        return $this->getPsrContainer()->get(LtiReplaceResultParserProxy::class);
     }
 }

--- a/manifest.php
+++ b/manifest.php
@@ -19,6 +19,7 @@
 
 use oat\tao\model\user\TaoRoles;
 use oat\taoLtiConsumer\controller\ResultController;
+use oat\taoLtiConsumer\model\ServiceProvider\ContainerServiceProvider;
 use oat\taoLtiConsumer\scripts\install\RegisterLtiDeliveryContainer;
 use oat\taoLtiConsumer\scripts\update\Updater;
 
@@ -48,5 +49,8 @@ return [
     ],
     'extra' => [
         'structures' => __DIR__ . DIRECTORY_SEPARATOR . 'controller' . DIRECTORY_SEPARATOR . 'structures.xml',
-    ]
+    ],
+    'containerServiceProviders' => [
+        ContainerServiceProvider::class,
+    ],
 ];

--- a/model/ServiceProvider/ContainerServiceProvider.php
+++ b/model/ServiceProvider/ContainerServiceProvider.php
@@ -22,10 +22,14 @@ declare(strict_types=1);
 
 namespace oat\taoLtiConsumer\model\ServiceProvider;
 
+use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 
+use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoLti\models\classes\Lis\LisAuthAdapterFactory;
+use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
 use oat\taoLti\models\classes\Security\AccessTokenRequestValidator;
+use oat\taoLtiConsumer\model\delivery\lookup\DeliveryLookupByDeliveryExecution;
 use oat\taoLtiConsumer\model\ltiProvider\repository\DeliveryLtiProviderRepository;
 use oat\taoLtiConsumer\model\result\messages\LisOutcomeRequestParser;
 use oat\taoLtiConsumer\model\result\operations\replace\Service\Lti1p1ReplaceResultParser;
@@ -70,6 +74,28 @@ class ContainerServiceProvider implements ContainerServiceProviderInterface
                 [
                     service(Lti1p1ReplaceResultParser::class),
                     service(Lti1p3ReplaceResultParser::class),
+                ]
+            );
+
+        $services
+            ->set(DeliveryLookupByDeliveryExecution::class, DeliveryLookupByDeliveryExecution::class)
+            ->public()
+            ->args(
+                [
+                    service(DeliveryExecutionService::SERVICE_ID)
+                ]
+            );
+
+        $services
+            ->set(DeliveryLtiProviderRepository::class, DeliveryLtiProviderRepository::class)
+            ->public()
+            ->args(
+                [
+                    service(LtiProviderService::SERVICE_ID),
+                    service(Ontology::SERVICE_ID),
+                    [
+                        service(DeliveryLookupByDeliveryExecution::class)
+                    ]
                 ]
             );
     }

--- a/model/ServiceProvider/ContainerServiceProvider.php
+++ b/model/ServiceProvider/ContainerServiceProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLtiConsumer\model\ServiceProvider;
+
+use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
+
+use oat\taoLti\models\classes\Lis\LisAuthAdapterFactory;
+use oat\taoLti\models\classes\Security\AccessTokenRequestValidator;
+use oat\taoLtiConsumer\model\ltiProvider\repository\DeliveryLtiProviderRepository;
+use oat\taoLtiConsumer\model\result\messages\LisOutcomeRequestParser;
+use oat\taoLtiConsumer\model\result\operations\replace\Service\Lti1p1ReplaceResultParser;
+use oat\taoLtiConsumer\model\result\operations\replace\Service\Lti1p3ReplaceResultParser;
+use oat\taoLtiConsumer\model\result\operations\replace\Service\LtiReplaceResultParserProxy;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\inline_service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\env;
+use function Symfony\Component\DependencyInjection\Loader\Configurator\param;
+
+class ContainerServiceProvider implements ContainerServiceProviderInterface
+{
+    public function __invoke(ContainerConfigurator $configurator): void
+    {
+        $services = $configurator->services();
+
+        $services
+            ->set(Lti1p1ReplaceResultParser::class, Lti1p1ReplaceResultParser::class)
+            ->args(
+                [
+                    service(LisOutcomeRequestParser::class),
+                    service(LisAuthAdapterFactory::class),
+                ]
+            );
+
+        $services
+            ->set(Lti1p3ReplaceResultParser::class, Lti1p3ReplaceResultParser::class)
+            ->args(
+                [
+                    service(LisOutcomeRequestParser::class),
+                    service(DeliveryLtiProviderRepository::class),
+                    service(AccessTokenRequestValidator::class),
+                ]
+            );
+
+        $services
+            ->set(LtiReplaceResultParserProxy::class, LtiReplaceResultParserProxy::class)
+            ->public()
+            ->args(
+                [
+                    service(Lti1p1ReplaceResultParser::class),
+                    service(Lti1p3ReplaceResultParser::class),
+                ]
+            );
+    }
+}

--- a/model/delivery/lookup/DeliveryLookupByDeliveryExecution.php
+++ b/model/delivery/lookup/DeliveryLookupByDeliveryExecution.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLtiConsumer\model\delivery\lookup;
+
+use oat\taoDelivery\model\execution\DeliveryExecutionService;
+
+class DeliveryLookupByDeliveryExecution implements DeliveryLookupInterface
+{
+    /** @var DeliveryExecutionService  */
+    private $deliveryExecutionService;
+
+    public function __construct(DeliveryExecutionService $deliveryExecutionService)
+    {
+        $this->deliveryExecutionService = $deliveryExecutionService;
+    }
+
+    public function searchBySourcedId(string $sourcedId)
+    {
+        $deliveryExecution = $this->deliveryExecutionService->getDeliveryExecution($sourcedId);
+        if (!$deliveryExecution->exists()) {
+            return null;
+        }
+
+        return $deliveryExecution->getDelivery();
+    }
+}

--- a/model/delivery/lookup/DeliveryLookupInterface.php
+++ b/model/delivery/lookup/DeliveryLookupInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2022 (original work) Open Assessment Technologies SA ;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLtiConsumer\model\delivery\lookup;
+
+interface DeliveryLookupInterface
+{
+    public function searchBySourcedId(string $sourcedId);
+}
+

--- a/model/delivery/lookup/DeliveryLookupInterface.php
+++ b/model/delivery/lookup/DeliveryLookupInterface.php
@@ -23,6 +23,9 @@ namespace oat\taoLtiConsumer\model\delivery\lookup;
 
 interface DeliveryLookupInterface
 {
+    /**
+     * Search for a delivery by the LTI lis_result_sourcedid parameter value
+     */
     public function searchBySourcedId(string $sourcedId);
 }
 

--- a/model/result/operations/replace/Service/Lti1p3ReplaceResultParser.php
+++ b/model/result/operations/replace/Service/Lti1p3ReplaceResultParser.php
@@ -66,7 +66,7 @@ class Lti1p3ReplaceResultParser implements ReplaceResultParserInterface
             throw new ParsingException('Lis request does not contain valid operation');
         }
 
-        $ltiProvider = $this->ltiProviderRepository->searchByDeliveryExecutionId(
+        $ltiProvider = $this->ltiProviderRepository->searchBySourcedId(
             $parsedPayload->getOperation()->getSourcedId()
         );
 

--- a/model/result/operations/replace/Service/LtiReplaceResultParserProxy.php
+++ b/model/result/operations/replace/Service/LtiReplaceResultParserProxy.php
@@ -29,8 +29,21 @@ use oat\taoLtiConsumer\model\result\ParsingException;
 use Psr\Http\Message\ServerRequestInterface;
 use tao_models_classes_UserException;
 
-class LtiReplaceResultParserProxy extends ConfigurableService implements ReplaceResultParserInterface
+class LtiReplaceResultParserProxy implements ReplaceResultParserInterface
 {
+    /** @var ReplaceResultParserInterface */
+    private $lti1p1Parser;
+    /** @var ReplaceResultParserInterface */
+    private $lti1p3Parser;
+
+    public function __construct(
+        ReplaceResultParserInterface $lti1p1Parser,
+        ReplaceResultParserInterface $lti1p3Parser
+    ) {
+        $this->lti1p3Parser = $lti1p3Parser;
+        $this->lti1p1Parser = $lti1p1Parser;
+    }
+
     /**
      * @throws ParsingException
      * @throws tao_models_classes_UserException
@@ -41,25 +54,15 @@ class LtiReplaceResultParserProxy extends ConfigurableService implements Replace
     public function parse(ServerRequestInterface $request): ReplaceResultOperationRequest
     {
         if ($this->isLti1p3($request)) {
-            return $this->getLti1p3ReplaceResultParser()->parse($request);
+            return $this->lti1p3Parser->parse($request);
         }
 
-        return $this->getLti1p1ReplaceResultParser()->parse($request);
+        return $this->lti1p1Parser->parse($request);
     }
 
     private function isLti1p3(ServerRequestInterface $request): bool
     {
         return $request->hasHeader('authorization') &&
             strpos($request->getHeader('authorization')[0], 'Bearer') === 0;
-    }
-
-    private function getLti1p1ReplaceResultParser(): ReplaceResultParserInterface
-    {
-        return $this->getServiceLocator()->get(Lti1p1ReplaceResultParser::class);
-    }
-
-    private function getLti1p3ReplaceResultParser(): ReplaceResultParserInterface
-    {
-        return $this->getServiceLocator()->get(Lti1p3ReplaceResultParser::class);
     }
 }

--- a/test/unit/model/result/operations/replace/Service/Lti1p1ReplaceResultParserTest.php
+++ b/test/unit/model/result/operations/replace/Service/Lti1p1ReplaceResultParserTest.php
@@ -51,18 +51,11 @@ class Lti1p1ReplaceResultParserTest extends TestCase
 
     public function setUp(): void
     {
-        $this->lisOutcomeRequestParserMock = $this->createMock(LisOutcomeRequestParser::class);
-        $this->lisAuthAdapterFactoryMock = $this->createMock(LisAuthAdapterFactory::class);
         $this->requestMock = $this->createMock(ServerRequestInterface::class);
 
-        $this->subject = new Lti1p1ReplaceResultParser();
-        $this->subject->setServiceLocator(
-            $this->getServiceLocatorMock(
-                [
-                    LisOutcomeRequestParser::class => $this->lisOutcomeRequestParserMock,
-                    LisAuthAdapterFactory::class => $this->lisAuthAdapterFactoryMock,
-                ]
-            )
+        $this->subject = new Lti1p1ReplaceResultParser(
+            $this->lisOutcomeRequestParserMock = $this->createMock(LisOutcomeRequestParser::class),
+            $this->lisAuthAdapterFactoryMock = $this->createMock(LisAuthAdapterFactory::class)
         );
     }
 

--- a/test/unit/model/result/operations/replace/Service/Lti1p3ReplaceResultParserTest.php
+++ b/test/unit/model/result/operations/replace/Service/Lti1p3ReplaceResultParserTest.php
@@ -74,7 +74,7 @@ class Lti1p3ReplaceResultParserTest extends TestCase
 
         $this->ltiProviderServiceMock
             ->expects($this->once())
-            ->method('searchByDeliveryExecutionId')
+            ->method('searchBySourcedId')
             ->willReturn($ltiProviderMock);
 
         $this->lisOutcomeRequestParserMock

--- a/test/unit/model/result/operations/replace/Service/Lti1p3ReplaceResultParserTest.php
+++ b/test/unit/model/result/operations/replace/Service/Lti1p3ReplaceResultParserTest.php
@@ -57,23 +57,14 @@ class Lti1p3ReplaceResultParserTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subject = new Lti1p3ReplaceResultParser();
+        $this->subject = new Lti1p3ReplaceResultParser(
+            $this->lisOutcomeRequestParserMock = $this->createMock(LisOutcomeRequestParser::class),
+            $this->ltiProviderServiceMock = $this->createMock(DeliveryLtiProviderRepository::class),
+            $this->accessTokenRequestValidatorMock = $this->createMock(AccessTokenRequestValidator::class)
+        );
 
-        $this->lisOutcomeRequestParserMock = $this->createMock(LisOutcomeRequestParser::class);
-        $this->ltiProviderServiceMock = $this->createMock(DeliveryLtiProviderRepository::class);
-        $this->accessTokenRequestValidatorMock = $this->createMock(AccessTokenRequestValidator::class);
         $this->lisOutcomeRequestMock = $this->createMock(LisOutcomeRequest::class);
         $this->requestMock = $this->createMock(ServerRequestInterface::class);
-
-        $this->subject->setServiceLocator(
-            $this->getServiceLocatorMock(
-                [
-                    LisOutcomeRequestParser::class => $this->lisOutcomeRequestParserMock,
-                    DeliveryLtiProviderRepository::class=> $this->ltiProviderServiceMock,
-                    AccessTokenRequestValidator::class => $this->accessTokenRequestValidatorMock,
-                ]
-            )
-        );
     }
 
     public function testParse(): void

--- a/test/unit/model/result/operations/replace/Service/LtiReplaceResultParserProxyTest.php
+++ b/test/unit/model/result/operations/replace/Service/LtiReplaceResultParserProxyTest.php
@@ -49,21 +49,13 @@ class LtiReplaceResultParserProxyTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->subject = new LtiReplaceResultParserProxy();
-        $this->lti1p1ReplaceResultParser = $this->createMock(Lti1p1ReplaceResultParser::class);
-        $this->lti1p3ReplaceResultParser = $this->createMock(Lti1p3ReplaceResultParser::class);
+        $this->subject = new LtiReplaceResultParserProxy(
+            $this->lti1p1ReplaceResultParser = $this->createMock(Lti1p1ReplaceResultParser::class),
+            $this->lti1p3ReplaceResultParser = $this->createMock(Lti1p3ReplaceResultParser::class)
+        );
         $this->replaceResultOperationRequestMock = $this->createMock(ReplaceResultOperationRequest::class);
 
         $this->requestMock = $this->createMock(ServerRequestInterface::class);
-
-        $this->subject->setServiceLocator(
-            $this->getServiceLocatorMock(
-                [
-                    Lti1p1ReplaceResultParser::class => $this->lti1p1ReplaceResultParser,
-                    Lti1p3ReplaceResultParser::class => $this->lti1p3ReplaceResultParser,
-                ]
-            )
-        );
     }
 
     public function testParseIsLti1p3(): void


### PR DESCRIPTION
Change the behavior how delivery is found by sourcedId. Use DI container to register services.
 
Related to : https://oat-sa.atlassian.net/browse/TR-3705
  
#### Dependencies
   
Companion PR :
 - [ ] https://github.com/oat-sa/extension-tao-deliver-connect/pull/108
 - [ ] https://github.com/oat-sa/tao-deliver-be/pull/843