### PR TITLE
Fix TR-3705 404 status code on resource not found 

### DIFF
--- a/controller/ResultController.php
+++ b/controller/ResultController.php
@@ -58,18 +58,15 @@ class ResultController extends tao_actions_CommonModule
 
         try {
             $operationRequest = $this->getLtiReplaceResultParser()->parse($this->getPsrRequest());
-        } catch (tao_models_classes_UserException $userException) {
-            throw $userException;
-        } catch (Throwable $throwable) {
-            $this->response = $this->createInternalErrorResponse($throwable);
-            return;
-        }
 
-        try {
             $this->response = $this->processLisRequest(
                 $operationRequest->getLisOutcomeRequest(),
                 $operationRequest->getLtiProvider()
             );
+        } catch (tao_models_classes_UserException $userException) {
+            throw $userException;
+        } catch (common_exception_NotFound $notFoundException) {
+            $this->response = $this->createNotFoundResponse($notFoundException);
         } catch (ParsingException $parsingException) {
             $this->response = $this->createParseErrorResponse($parsingException);
         } catch (Throwable $throwable) {
@@ -111,6 +108,15 @@ class ResultController extends tao_actions_CommonModule
             default:
                 return StatusCode::HTTP_INTERNAL_SERVER_ERROR;
         }
+    }
+
+    private function createNotFoundResponse(common_exception_NotFound $notFoundException): ResponseInterface
+    {
+        return $this->getXmlFailureResponse(
+            StatusCode::HTTP_NOT_FOUND,
+            LisOutcomeResponseInterface::STATUS_NOT_FOUND,
+            $notFoundException->getMessage()
+        );
     }
 
     private function createParseErrorResponse(ParsingException $parsingException): ResponseInterface

--- a/model/ltiProvider/repository/DeliveryLtiProviderRepository.php
+++ b/model/ltiProvider/repository/DeliveryLtiProviderRepository.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoLtiConsumer\model\ltiProvider\repository;
 
+use common_exception_NotFound;
 use oat\generis\model\data\Ontology;
 use oat\taoDeliveryRdf\model\ContainerRuntime;
 use oat\taoLti\models\classes\LtiException;
@@ -50,6 +51,10 @@ class DeliveryLtiProviderRepository
         $this->deliveryLookupProviders = $deliveryLookupProviders;
     }
 
+    /**
+     * @throws LtiException
+     * @throws common_exception_NotFound
+     */
     public function searchBySourcedId(string $sourcedId): LtiProvider
     {
         $delivery = $this->findDelivery($sourcedId);
@@ -68,6 +73,9 @@ class DeliveryLtiProviderRepository
         return $this->ltiProviderRepository->searchById($containerJson['params']['ltiProvider']);
     }
 
+    /**
+     * @throws common_exception_NotFound
+     */
     private function findDelivery(string $sourcedId)
     {
         /** @var DeliveryLookupInterface $provider */
@@ -77,6 +85,6 @@ class DeliveryLtiProviderRepository
             }
         }
 
-        throw new LtiException('Could not find delivery for provided sourcedId');
+        throw new common_exception_NotFound(sprintf("Resource '%s' not found", $sourcedId));
     }
 }

--- a/model/result/operations/replace/Service/Lti1p3ReplaceResultParser.php
+++ b/model/result/operations/replace/Service/Lti1p3ReplaceResultParser.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 
 namespace oat\taoLtiConsumer\model\result\operations\replace\Service;
 
-use oat\oatbox\service\ConfigurableService;
+use common_exception_NotFound;
 use oat\taoLti\models\classes\LtiException;
 use oat\taoLti\models\classes\Security\AccessTokenRequestValidator;
 use oat\taoLtiConsumer\model\ltiProvider\repository\DeliveryLtiProviderRepository;
@@ -30,7 +30,6 @@ use oat\taoLtiConsumer\model\result\messages\LisOutcomeRequestParser;
 use oat\taoLtiConsumer\model\result\operations\replace\ReplaceResultOperationRequest;
 use oat\taoLtiConsumer\model\result\ParsingException;
 use Psr\Http\Message\ServerRequestInterface;
-use tao_models_classes_UserException;
 
 class Lti1p3ReplaceResultParser implements ReplaceResultParserInterface
 {
@@ -56,7 +55,7 @@ class Lti1p3ReplaceResultParser implements ReplaceResultParserInterface
     /**
      * @throws ParsingException
      * @throws LtiException
-     * @throws tao_models_classes_UserException
+     * @throws common_exception_NotFound
      */
     public function parse(ServerRequestInterface $request): ReplaceResultOperationRequest
     {


### PR DESCRIPTION
Change the response code for `/taoLtiConsumer/ResultController/manageResults` response when delivery execution or delivery can not be identified from `lis_result_sourcedid`. 
 
Related to : https://oat-sa.atlassian.net/browse/TR-3705
   
#### How to test
 
- launch a test with LTI 1p3 specifying BasicOutcome claim 
```
    "https://purl.imsglobal.org/spec/lti-bo/claim/basicoutcome": {
        "lis_result_sourcedid": "NON-EXISTING-DELIVERY-EXECUTION-ID",
        "lis_outcome_service_url": "{TERRE_HOST}/taoLtiConsumer/ResultController/manageResults"
    }
```
- complete the test
- check the log message of terre, verify that 404 response has been returned