### PR TITLE
Receive not prefixed DeliveryExecutionId

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,0 +1,27 @@
+name: Continuous integration
+
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ develop, feat/*, feature/* ]
+
+jobs:
+  ci:
+    runs-on: ${{ matrix.operating-system }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ ubuntu-latest ]
+        php-version: [ '7.4', '8.0', '8.1' ]
+        include:
+          - php-version: '7.4'
+            coverage: true
+
+    steps:
+      - name: CI
+        uses: oat-sa/tao-extension-ci-action@v1
+        with:
+          php: ${{ matrix.php-version }}
+          coverage: ${{ matrix.coverage }}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     "tao-extension-name" : "taoLtiConsumer"
   },
   "require-dev": {
-    "php-mock/php-mock": ">=2.3.1"
+    "php-mock/php-mock": "^2.3"
   },
   "require": {
     "ext-dom": "*",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "oat-sa/generis" : ">=14.0.0",
     "oat-sa/tao-core" : ">=47.0.0",
     "oat-sa/extension-tao-lti" : ">=15.7.1",
-    "oat-sa/extension-tao-delivery" : ">=15.0.0",
+    "oat-sa/extension-tao-delivery" : ">=15.13.0",
     "oat-sa/extension-tao-delivery-rdf" : ">=14.0.0",
     "oat-sa/extension-tao-outcome" : ">=13.0.0"
   },

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
   "extra" : {
     "tao-extension-name" : "taoLtiConsumer"
   },
+  "require-dev": {
+    "php-mock/php-mock": ">=2.3.1"
+  },
   "require": {
     "ext-dom": "*",
     "ext-simplexml": "*",

--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -61,7 +61,7 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
             ],
             [
                 new BasicOutcomeClaim(
-                    $execution->getIdentifier(),
+                    $execution->getOriginalIdentifier(),
                     $this->getLisOutcomeServiceUrlFactory()->create()
                 ),
             ],

--- a/model/result/ResultService.php
+++ b/model/result/ResultService.php
@@ -129,7 +129,7 @@ class ResultService extends ConfigurableService
         /** @var EventManager $eventManager*/
         $eventManager = $this->getServiceLocator()->get(EventManager::SERVICE_ID);
         /** @noinspection PhpUnhandledExceptionInspection */
-        $eventManager->trigger(new LisScoreReceivedEvent($deliveryExecution->getIdentifier()));
+        $eventManager->trigger(new LisScoreReceivedEvent($deliveryExecution->getOriginalIdentifier()));
 
         $this->logInfo(
             sprintf(

--- a/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
+++ b/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
@@ -67,7 +67,7 @@ class Lti1p3DeliveryLaunchCommandFactoryTest extends TestCase
     {
         $execution = $this->createMock(DeliveryExecution::class);
 
-        $execution->method('getIdentifier')
+        $execution->method('getOriginalIdentifier')
             ->willReturn('deliveryExecutionIdentifier');
 
         $ltiProvider = $this->createMock(LtiProvider::class);

--- a/test/unit/model/result/ResultServiceTest.php
+++ b/test/unit/model/result/ResultServiceTest.php
@@ -69,7 +69,7 @@ class ResultServiceTest extends TestCase
 
         /** @var DeliveryExecutionInterface|MockObject $deliveryExecutionMock */
         $deliveryExecutionMock = $this->createMock(DeliveryExecution::class);
-        $deliveryExecutionMock->method('getIdentifier')->willReturn('de_id');
+        $deliveryExecutionMock->method('getOriginalIdentifier')->willReturn('de_id');
 
         /** @var ScoreWriterService|MockObject $scoreWritterMock */
         $scoreWritterMock = $this->createMock(ScoreWriterService::class);


### PR DESCRIPTION
# [TR-4622](https://oat-sa.atlassian.net/browse/TR-4622)

## Related PR's
1. [extension-tao-delivery](https://github.com/oat-sa/extension-tao-delivery/pull/555) 
2. [extension-tao-deliver-connect](https://github.com/oat-sa/extension-tao-deliver-connect/pull/132)

## Description
Looks like storage implementation add their own prefixes to DeliveryExecutionId, but for receive result we should use original one 

## Step to reproduce
1. Publish delivery
2. Use That [link](http://devkit.docker.localhost/platform/message/launch/lti-resource-link?registration=deliverRegistration&user_list=c3po&launch_url=https://deliver.docker.localhost/api/v1/auth/launch-lti-1p3/%3Cdelivery_id%3E&claims=%7B%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti/claim/roles%22:%20%5B%0D%0A%20%20%20%20%20%20%20%20%22http://purl.imsglobal.org/vocab/lis/v2/membership%23Learner%22%0D%0A%20%20%20%20%5D,%0D%0A%20%20%20%20%22https://purl.imsglobal.org/spec/lti-bo/claim/basicoutcome%22:%20%7B%0D%0A%20%20%20%20%20%20%20%20%22lis_result_sourcedid%22:%20%22%3Cdelivery_id%3E-1%22,%0D%0A%20%20%20%20%20%20%20%20%22lis_outcome_service_url%22:%20%22http://backoffice.docker.localhost/taoLtiConsumer/ResultController/manageResults%22%0D%0A%20%20%20%20%7D%0D%0A%7D) to create proper outcome
3. Log in as Admin and choose 'Results' tab
4. Select completed delivery and click 'View' button
5. Results should appeared

## Development impact 
1. Replace to use new metod `getIdentifier()` -> `getOriginalIdentifier()`
2. Updated tests according to development changes 

## Demo 
[in progress ](https://user-images.githubusercontent.com/2750628/190760754-15d01e4c-69f0-4d81-b971-ad399a690ab0.mov)



