### PR TITLE
Replace margin with padding to allow proper hiding block

### DIFF
--- a/views/scss/wizard.scss
+++ b/views/scss/wizard.scss
@@ -40,7 +40,7 @@
                 }
             }
             nav {
-                margin-bottom: 30px;
+                padding-bottom: 30px;
             }
         }
     }


### PR DESCRIPTION
Work is done under [REL-872](https://oat-sa.atlassian.net/browse/REL-872)

The solution is planned to hide tabs for selecting targets for publishing in case TAO CG  only feature flag is used. But, when tabs are hidden, the wrapper block remains and because it has a margin, it changes the height of the parent element. Replacing the margin with padding still solves the issue of indentation but allows to hide of the block entirely when it is required.