### PR TITLE
fix: set return url for all LTI13 requests to solar

### DIFF
--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -97,5 +97,4 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
         }
         return _url('index', 'DeliveryServer', 'taoDelivery');
     }
-
 }

--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -28,13 +28,13 @@ use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
 use oat\taoDelivery\model\execution\DeliveryExecution;
-use oat\taoDelivery\models\classes\ReturnUrlService;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLti\models\classes\Tool\Factory\LtiLaunchCommandFactoryInterface;
 use oat\taoLti\models\classes\Tool\LtiLaunchCommand;
 use oat\taoLti\models\classes\Tool\LtiLaunchCommandInterface;
 use oat\taoLtiConsumer\model\Tool\Service\ResourceLinkIdDiscover;
 use oat\taoLtiConsumer\model\Tool\Service\ResourceLinkIdDiscoverInterface;
+use tao_helpers_Uri;
 
 class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements LtiLaunchCommandFactoryInterface
 {
@@ -90,11 +90,8 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
         return $this->getServiceLocator()->get(LisOutcomeServiceUrlFactory::class);
     }
 
-    private function getReturnUrl()
+    private function getReturnUrl(): string
     {
-        if ($this->getServiceLocator()->has(ReturnUrlService::SERVICE_ID)) {
-            return $this->getServiceLocator()->get(ReturnUrlService::SERVICE_ID)->getReturnUrl();
-        }
-        return _url('index', 'DeliveryServer', 'taoDelivery');
+        return tao_helpers_Uri::getRootUrl();
     }
 }

--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -24,9 +24,11 @@ namespace oat\taoLtiConsumer\model\Tool\Factory;
 
 use oat\generis\model\OntologyAwareTrait;
 use OAT\Library\Lti1p3Core\Message\Payload\Claim\BasicOutcomeClaim;
+use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
 use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\models\classes\ReturnUrlService;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLti\models\classes\Tool\Factory\LtiLaunchCommandFactoryInterface;
 use oat\taoLti\models\classes\Tool\LtiLaunchCommand;
@@ -64,6 +66,7 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
                     $execution->getOriginalIdentifier(),
                     $this->getLisOutcomeServiceUrlFactory()->create()
                 ),
+                LtiMessagePayloadInterface::CLAIM_LTI_LAUNCH_PRESENTATION => ['return_url' => $this->getReturnUrl()],
             ],
             $resourceIdentifier,
             $user,
@@ -86,4 +89,13 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
     {
         return $this->getServiceLocator()->get(LisOutcomeServiceUrlFactory::class);
     }
+
+    private function getReturnUrl()
+    {
+        if ($this->getServiceLocator()->has(ReturnUrlService::SERVICE_ID)) {
+            return $this->getServiceLocator()->get(ReturnUrlService::SERVICE_ID)->getReturnUrl();
+        }
+        return _url('index', 'DeliveryServer', 'taoDelivery');
+    }
+
 }

--- a/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
+++ b/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
@@ -106,6 +106,7 @@ class Lti1p3DeliveryLaunchCommandFactoryTest extends TestCase
                     'deliveryExecutionIdentifier',
                     'outcomeServiceUrl'
                 ),
+                'https://purl.imsglobal.org/spec/lti/claim/launch_presentation' => ['return_url' => _url('index', 'DeliveryServer', 'taoDelivery')]
             ],
             'deliveryExecutionIdentifier',
             $user,

--- a/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
+++ b/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *  This program is free software; you can redistribute it and/or
  *  modify it under the terms of the GNU General Public License

--- a/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
+++ b/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
@@ -32,6 +32,7 @@ use oat\taoLtiConsumer\model\Tool\Factory\Lti1p3DeliveryLaunchCommandFactory;
 use oat\taoLtiConsumer\model\Tool\Service\ResourceLinkIdDiscover;
 use oat\taoLtiConsumer\model\Tool\Service\ResourceLinkIdDiscoverInterface;
 use PHPUnit\Framework\MockObject\MockObject;
+use tao_helpers_Uri;
 
 class Lti1p3DeliveryLaunchCommandFactoryTest extends TestCase
 {
@@ -122,6 +123,6 @@ class Lti1p3DeliveryLaunchCommandFactoryTest extends TestCase
 
     private function getReturnUrl(): string
     {
-        return _url('index', 'DeliveryServer', 'taoDelivery');
+        return tao_helpers_Uri::getRootUrl();
     }
 }

--- a/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
+++ b/test/unit/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactoryTest.php
@@ -106,7 +106,9 @@ class Lti1p3DeliveryLaunchCommandFactoryTest extends TestCase
                     'deliveryExecutionIdentifier',
                     'outcomeServiceUrl'
                 ),
-                'https://purl.imsglobal.org/spec/lti/claim/launch_presentation' => ['return_url' => _url('index', 'DeliveryServer', 'taoDelivery')]
+                'https://purl.imsglobal.org/spec/lti/claim/launch_presentation' => [
+                    'return_url' => $this->getReturnUrl()
+                ]
             ],
             'deliveryExecutionIdentifier',
             $user,
@@ -115,5 +117,10 @@ class Lti1p3DeliveryLaunchCommandFactoryTest extends TestCase
         );
 
         $this->assertEquals($expectedCommand, $this->subject->create($config));
+    }
+
+    private function getReturnUrl(): string
+    {
+        return _url('index', 'DeliveryServer', 'taoDelivery');
     }
 }


### PR DESCRIPTION
Ticket: TR-4295

## What's Changed

- Add a return_url link to the set of claims by TAO 3.x when it acts as a platform

**Preconditions:**

1. A created test
2. Remotely published test

**Steps to reproduce and test:**

1. Log in as Test-Taker or Guest
2. Choose created test
3. Pass the test

**Actual result**: No any button or automatically redirection to the Home page
**Expected result**: Automatically or manually redirection to the Home page

**Checklist:**
- [ ] New code is covered by tests (if applicable)
- [ ] Tests are running successfully (old and new ones) on my local machine (if applicable)
- [ ] New code is respecting code style rules
- [ ] New code is respecting best practices
- [ ] New code is not subject to concurrency issues (if applicable)
- [ ] Feature is working correctly on my local machine (if applicable)
- [ ] Acceptance criteria are respected
- [ ] Pull request title and description are meaningful
- [ ] Pull request's target is not `master`