### PR TITLE
Provide new exit url endpoint to finalise state of LTI1p3 executions

### DIFF
--- a/controller/ResultController.php
+++ b/controller/ResultController.php
@@ -22,12 +22,9 @@ declare(strict_types=1);
 
 namespace oat\taoLtiConsumer\controller;
 
-use common_exception_BadRequest;
-use common_exception_ClientException;
 use common_exception_Error;
 use common_exception_MethodNotAllowed;
 use common_exception_NotFound;
-use oat\oatbox\log\LoggerService;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLtiConsumer\model\RemoteDeliverySubmittingService;
 use oat\taoLtiConsumer\model\result\messages\LisOutcomeRequest;
@@ -46,6 +43,7 @@ use tao_actions_CommonModule;
 use tao_helpers_Uri;
 use tao_models_classes_UserException;
 use Throwable;
+
 use function GuzzleHttp\Psr7\stream_for;
 
 class ResultController extends tao_actions_CommonModule

--- a/model/RemoteDeliverySubmittingService.php
+++ b/model/RemoteDeliverySubmittingService.php
@@ -1,0 +1,93 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLtiConsumer\model;
+
+use oat\tao\helpers\UrlHelper;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\model\execution\DeliveryExecutionService;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+
+class RemoteDeliverySubmittingService
+{
+    private const EXECUTION_ID_QUERY_PARAM = 'execution';
+    private const LTI_ERROR_MSG_QUERY_PARAM = 'lti_errormsg';
+    private const LTI_ERROR_LOG_QUERY_PARAM = 'lti_errorlog';
+    private const IRRECOVERABLE_ERROR_LOG_HINT = '[IRRECOVERABLE]';
+
+    private UrlHelper $urlHelper;
+    private DeliveryExecutionService $deliveryExecutionService;
+
+    public function __construct(UrlHelper $urlHelper, DeliveryExecutionService $deliveryExecutionService)
+    {
+        $this->urlHelper = $urlHelper;
+        $this->deliveryExecutionService = $deliveryExecutionService;
+    }
+
+    public function provideSubmitUrl(string $executionId): string
+    {
+        return $this->urlHelper->buildUrl(
+            'submitRemoteExecution',
+            'ResultController',
+            'taoLtiConsumer',
+            [self::EXECUTION_ID_QUERY_PARAM => $executionId]
+        );
+    }
+
+    public function submitRemoteExecution(array $queryParams): void
+    {
+        if (!array_key_exists(self::EXECUTION_ID_QUERY_PARAM, $queryParams)) {
+            throw new RuntimeException('Execution id is not provided');
+        }
+        $deliveryExecution = $this->deliveryExecutionService->getDeliveryExecution(
+            $queryParams[self::EXECUTION_ID_QUERY_PARAM]
+        );
+
+        if (
+            in_array(
+                $deliveryExecution->getState()->getUri(),
+                [DeliveryExecutionInterface::STATE_TERMINATED, DeliveryExecutionInterface::STATE_FINISHED]
+            )
+        ) {
+            return;
+        }
+
+        if (!(
+            array_key_exists(self::LTI_ERROR_MSG_QUERY_PARAM, $queryParams)
+            || array_key_exists(self::LTI_ERROR_LOG_QUERY_PARAM, $queryParams)
+        )) {
+            $deliveryExecution->setState(DeliveryExecution::STATE_FINISHED);
+            return;
+        }
+
+        if (
+            array_key_exists(self::LTI_ERROR_LOG_QUERY_PARAM, $queryParams)
+            && strpos($queryParams[self::LTI_ERROR_LOG_QUERY_PARAM], self::IRRECOVERABLE_ERROR_LOG_HINT) !== false
+        ) {
+            $deliveryExecution->setState(DeliveryExecution::STATE_TERMINATED);
+            return;
+        }
+
+        throw new RuntimeException($queryParams[self::LTI_ERROR_MSG_QUERY_PARAM] ?? 'Unknown error');
+    }
+}

--- a/model/RemoteDeliverySubmittingService.php
+++ b/model/RemoteDeliverySubmittingService.php
@@ -22,8 +22,8 @@ declare(strict_types=1);
 
 namespace oat\taoLtiConsumer\model;
 
-use oat\tao\helpers\UrlHelper;
 use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\tao\helpers\UrlHelper;
 use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
 use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
@@ -76,7 +76,7 @@ class RemoteDeliverySubmittingService
             array_key_exists(self::LTI_ERROR_MSG_QUERY_PARAM, $queryParams)
             || array_key_exists(self::LTI_ERROR_LOG_QUERY_PARAM, $queryParams)
         )) {
-            $deliveryExecution->setState(DeliveryExecution::STATE_FINISHED);
+            $deliveryExecution->setState(DeliveryExecutionInterface::STATE_FINISHED);
             return;
         }
 
@@ -84,7 +84,7 @@ class RemoteDeliverySubmittingService
             array_key_exists(self::LTI_ERROR_LOG_QUERY_PARAM, $queryParams)
             && strpos($queryParams[self::LTI_ERROR_LOG_QUERY_PARAM], self::IRRECOVERABLE_ERROR_LOG_HINT) !== false
         ) {
-            $deliveryExecution->setState(DeliveryExecution::STATE_TERMINATED);
+            $deliveryExecution->setState(DeliveryExecutionInterface::STATE_TERMINATED);
             return;
         }
 

--- a/model/RemoteDeliverySubmittingService.php
+++ b/model/RemoteDeliverySubmittingService.php
@@ -73,10 +73,8 @@ class RemoteDeliverySubmittingService
         }
 
         if (
-            !(
-                array_key_exists(self::LTI_ERROR_MSG_QUERY_PARAM, $queryParams)
-                || array_key_exists(self::LTI_ERROR_LOG_QUERY_PARAM, $queryParams)
-            )
+            !array_key_exists(self::LTI_ERROR_MSG_QUERY_PARAM, $queryParams)
+            && !array_key_exists(self::LTI_ERROR_LOG_QUERY_PARAM, $queryParams)
         ) {
             $deliveryExecution->setState(DeliveryExecutionInterface::STATE_FINISHED);
             return;

--- a/model/RemoteDeliverySubmittingService.php
+++ b/model/RemoteDeliverySubmittingService.php
@@ -72,10 +72,12 @@ class RemoteDeliverySubmittingService
             return;
         }
 
-        if (!(
-            array_key_exists(self::LTI_ERROR_MSG_QUERY_PARAM, $queryParams)
-            || array_key_exists(self::LTI_ERROR_LOG_QUERY_PARAM, $queryParams)
-        )) {
+        if (
+            !(
+                array_key_exists(self::LTI_ERROR_MSG_QUERY_PARAM, $queryParams)
+                || array_key_exists(self::LTI_ERROR_LOG_QUERY_PARAM, $queryParams)
+            )
+        ) {
             $deliveryExecution->setState(DeliveryExecutionInterface::STATE_FINISHED);
             return;
         }

--- a/model/ServiceProvider/ContainerServiceProvider.php
+++ b/model/ServiceProvider/ContainerServiceProvider.php
@@ -25,12 +25,14 @@ namespace oat\taoLtiConsumer\model\ServiceProvider;
 use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
 
+use oat\tao\helpers\UrlHelper;
 use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoLti\models\classes\Lis\LisAuthAdapterFactory;
 use oat\taoLti\models\classes\LtiProvider\LtiProviderService;
 use oat\taoLti\models\classes\Security\AccessTokenRequestValidator;
 use oat\taoLtiConsumer\model\delivery\lookup\DeliveryLookupByDeliveryExecution;
 use oat\taoLtiConsumer\model\ltiProvider\repository\DeliveryLtiProviderRepository;
+use oat\taoLtiConsumer\model\RemoteDeliverySubmittingService;
 use oat\taoLtiConsumer\model\result\messages\LisOutcomeRequestParser;
 use oat\taoLtiConsumer\model\result\operations\replace\Service\Lti1p1ReplaceResultParser;
 use oat\taoLtiConsumer\model\result\operations\replace\Service\Lti1p3ReplaceResultParser;
@@ -96,6 +98,16 @@ class ContainerServiceProvider implements ContainerServiceProviderInterface
                     [
                         service(DeliveryLookupByDeliveryExecution::class)
                     ]
+                ]
+            );
+
+        $services
+            ->set(RemoteDeliverySubmittingService::class, RemoteDeliverySubmittingService::class)
+            ->public()
+            ->args(
+                [
+                    service(UrlHelper::class),
+                    service(DeliveryExecutionService::SERVICE_ID)
                 ]
             );
     }

--- a/model/ServiceProvider/ContainerServiceProvider.php
+++ b/model/ServiceProvider/ContainerServiceProvider.php
@@ -24,7 +24,6 @@ namespace oat\taoLtiConsumer\model\ServiceProvider;
 
 use oat\generis\model\data\Ontology;
 use oat\generis\model\DependencyInjection\ContainerServiceProviderInterface;
-
 use oat\tao\helpers\UrlHelper;
 use oat\taoDelivery\model\execution\DeliveryExecutionService;
 use oat\taoLti\models\classes\Lis\LisAuthAdapterFactory;

--- a/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
+++ b/model/Tool/Factory/Lti1p3DeliveryLaunchCommandFactory.php
@@ -27,13 +27,16 @@ use OAT\Library\Lti1p3Core\Message\Payload\Claim\BasicOutcomeClaim;
 use OAT\Library\Lti1p3Core\Message\Payload\LtiMessagePayloadInterface;
 use oat\oatbox\service\ConfigurableService;
 use oat\oatbox\session\SessionService;
+use oat\tao\helpers\UrlHelper;
 use oat\taoDelivery\model\execution\DeliveryExecution;
 use oat\taoLti\models\classes\LtiProvider\LtiProvider;
 use oat\taoLti\models\classes\Tool\Factory\LtiLaunchCommandFactoryInterface;
 use oat\taoLti\models\classes\Tool\LtiLaunchCommand;
 use oat\taoLti\models\classes\Tool\LtiLaunchCommandInterface;
+use oat\taoLtiConsumer\model\RemoteDeliverySubmittingService;
 use oat\taoLtiConsumer\model\Tool\Service\ResourceLinkIdDiscover;
 use oat\taoLtiConsumer\model\Tool\Service\ResourceLinkIdDiscoverInterface;
+use Ramsey\Uuid\Uuid;
 use tao_helpers_Uri;
 
 class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements LtiLaunchCommandFactoryInterface
@@ -66,7 +69,11 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
                     $execution->getOriginalIdentifier(),
                     $this->getLisOutcomeServiceUrlFactory()->create()
                 ),
-                LtiMessagePayloadInterface::CLAIM_LTI_LAUNCH_PRESENTATION => ['return_url' => $this->getReturnUrl()],
+                LtiMessagePayloadInterface::CLAIM_LTI_LAUNCH_PRESENTATION => [
+                    'return_url' => $this->getRemoteDeliverySubmittingService()->provideSubmitUrl(
+                        $execution->getOriginalIdentifier()
+                    ),
+                ],
             ],
             $resourceIdentifier,
             $user,
@@ -90,8 +97,8 @@ class Lti1p3DeliveryLaunchCommandFactory extends ConfigurableService implements 
         return $this->getServiceLocator()->get(LisOutcomeServiceUrlFactory::class);
     }
 
-    private function getReturnUrl(): string
+    private function getRemoteDeliverySubmittingService(): RemoteDeliverySubmittingService
     {
-        return tao_helpers_Uri::getRootUrl();
+        return $this->getServiceLocator()->getContainer()->get(RemoteDeliverySubmittingService::class);
     }
 }

--- a/test/unit/model/RemoteDeliverySubmittingServiceTest.php
+++ b/test/unit/model/RemoteDeliverySubmittingServiceTest.php
@@ -1,0 +1,195 @@
+<?php
+
+/**
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; under version 2
+ * of the License (non-upgradable).
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * Copyright (c) 2023 (original work) Open Assessment Technologies SA;
+ */
+
+declare(strict_types=1);
+
+namespace oat\taoLtiConsumer\test\unit\model;
+
+use core_kernel_classes_Resource;
+use oat\taoLtiConsumer\model\RemoteDeliverySubmittingService;
+use oat\taoDelivery\model\execution\DeliveryExecution;
+use oat\taoDelivery\model\execution\DeliveryExecutionInterface;
+use oat\taoDelivery\model\execution\DeliveryExecutionService;
+use oat\tao\helpers\UrlHelper;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\Exception\RuntimeException;
+
+class RemoteDeliverySubmittingServiceTest extends TestCase
+{
+    private const EXECUTION_ID_QUERY_PARAM = 'execution';
+    private const LTI_ERROR_MSG_QUERY_PARAM = 'lti_errormsg';
+    private const LTI_ERROR_LOG_QUERY_PARAM = 'lti_errorlog';
+    private const IRRECOVERABLE_ERROR_LOG_HINT = '[IRRECOVERABLE]';
+    private const EXPECTED_EXECUTION_ID = 'execution_id';
+
+    private RemoteDeliverySubmittingService $service;
+    private UrlHelper $urlHelper;
+    private DeliveryExecutionService $executionService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->urlHelper = $this->createMock(UrlHelper::class);
+        $this->executionService = $this->createMock(DeliveryExecutionService::class);
+
+        $this->service = new RemoteDeliverySubmittingService($this->urlHelper, $this->executionService);
+    }
+
+    public function testProvideSubmitUrl()
+    {
+        $this->urlHelper->expects($this->once())
+            ->method('buildUrl')
+            ->with(
+                'submitRemoteExecution',
+                'ResultController',
+                'taoLtiConsumer',
+                [self::EXECUTION_ID_QUERY_PARAM => 'execution_id']
+            )
+            ->willReturn('http://example.com/submitRemoteExecution?execution=execution_id');
+
+        $submitUrl = $this->service->provideSubmitUrl(self::EXPECTED_EXECUTION_ID);
+
+        $this->assertEquals('http://example.com/submitRemoteExecution?execution=execution_id', $submitUrl);
+    }
+
+    public function testSubmitRemoteExecutionWithMissingExecutionIdQueryParam()
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Execution id is not provided');
+
+        $this->service->submitRemoteExecution([]);
+    }
+
+    public function testSubmitRemoteExecutionWithTerminatedOrFinishedState()
+    {
+        $queryParams = [self::EXECUTION_ID_QUERY_PARAM => self::EXPECTED_EXECUTION_ID];
+
+        $execution = $this->createMock(DeliveryExecutionInterface::class);
+        $stateMock = $this->createMock(core_kernel_classes_Resource::class);
+        $stateMock->expects($this->once())
+            ->method('getUri')
+            ->willReturn(DeliveryExecutionInterface::STATE_TERMINATED);
+        $execution->expects($this->once())
+            ->method('getState')
+            ->willReturn($stateMock);
+
+        $this->executionService->expects($this->once())
+            ->method('getDeliveryExecution')
+            ->with(self::EXPECTED_EXECUTION_ID)
+            ->willReturn($execution);
+
+        $this->service->submitRemoteExecution($queryParams);
+
+        // No assertions needed as the method should return without throwing an exception
+    }
+
+    public function testSubmitRemoteExecutionWithoutErrorParams()
+    {
+        $queryParams = [self::EXECUTION_ID_QUERY_PARAM => self::EXPECTED_EXECUTION_ID];
+
+        $execution = $this->createMock(DeliveryExecutionInterface::class);
+        $stateMock = $this->createMock(core_kernel_classes_Resource::class);
+        $stateMock->expects($this->once())
+            ->method('getUri')
+            ->willReturn(DeliveryExecutionInterface::STATE_ACTIVE);
+        $execution->expects($this->once())
+            ->method('getState')
+            ->willReturn($stateMock);
+
+        $execution->expects($this->once())
+            ->method('setState')
+            ->with(DeliveryExecutionInterface::STATE_FINISHED);
+
+        $this->executionService->expects($this->once())
+            ->method('getDeliveryExecution')
+            ->with(self::EXPECTED_EXECUTION_ID)
+            ->willReturn($execution);
+
+        $this->service->submitRemoteExecution($queryParams);
+
+        // No assertions needed as the method should return without throwing an exception
+    }
+
+    public function testSubmitRemoteExecutionWithIrrecoverableErrorLog()
+    {
+        $queryParams = [
+            self::EXECUTION_ID_QUERY_PARAM => self::EXPECTED_EXECUTION_ID,
+            self::LTI_ERROR_LOG_QUERY_PARAM => 'Some error log ' . self::IRRECOVERABLE_ERROR_LOG_HINT,
+        ];
+
+        $execution = $this->createMock(DeliveryExecutionInterface::class);
+        $stateMock = $this->createMock(core_kernel_classes_Resource::class);
+        $stateMock->expects($this->once())
+            ->method('getUri')
+            ->willReturn(DeliveryExecutionInterface::STATE_ACTIVE);
+        $execution->expects($this->once())
+            ->method('getState')
+            ->willReturn($stateMock);
+
+        $execution->expects($this->once())
+            ->method('setState')
+            ->with(DeliveryExecution::STATE_TERMINATED);
+
+        $this->executionService->expects($this->once())
+            ->method('getDeliveryExecution')
+            ->with(self::EXPECTED_EXECUTION_ID)
+            ->willReturn($execution);
+
+        $this->service->submitRemoteExecution($queryParams);
+
+        // No assertions needed as the method should return without throwing an exception
+    }
+
+    public function testSubmitRemoteExecutionWithThrownLtiMsg()
+    {
+        $queryParams = [
+            self::EXECUTION_ID_QUERY_PARAM => self::EXPECTED_EXECUTION_ID,
+            self::LTI_ERROR_LOG_QUERY_PARAM => 'Some error log ',
+            self::LTI_ERROR_MSG_QUERY_PARAM => 'Some error message'
+        ];
+
+        $execution = $this->createMock(DeliveryExecutionInterface::class);
+        $stateMock = $this->createMock(core_kernel_classes_Resource::class);
+        $stateMock->expects($this->once())
+            ->method('getUri')
+            ->willReturn(DeliveryExecutionInterface::STATE_ACTIVE);
+        $execution->expects($this->once())
+            ->method('getState')
+            ->willReturn($stateMock);
+
+        $execution->expects($this->never())
+            ->method('setState')
+            ->with(DeliveryExecutionInterface::STATE_TERMINATED);
+
+        $this->executionService->expects($this->once())
+            ->method('getDeliveryExecution')
+            ->with(self::EXPECTED_EXECUTION_ID)
+            ->willReturn($execution);
+
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Some error message');
+
+        $this->service->submitRemoteExecution($queryParams);
+
+        // No assertions needed as the method should return without throwing an exception
+    }
+}

--- a/test/unit/model/RemoteDeliverySubmittingServiceTest.php
+++ b/test/unit/model/RemoteDeliverySubmittingServiceTest.php
@@ -70,6 +70,24 @@ class RemoteDeliverySubmittingServiceTest extends TestCase
         $this->assertEquals('http://example.com/submitRemoteExecution?execution=execution_id', $submitUrl);
     }
 
+    public function testProvideSubmitUrlWithRuntimeError()
+    {
+        $this->urlHelper->expects($this->once())
+            ->method('buildUrl')
+            ->with(
+                'submitRemoteExecution',
+                'ResultController',
+                'taoLtiConsumer',
+                [self::EXECUTION_ID_QUERY_PARAM => 'execution_id']
+            )
+            ->willThrowException(new RuntimeException('Runtime error'));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Runtime error');
+
+        $this->service->provideSubmitUrl(self::EXPECTED_EXECUTION_ID);
+    }
+
     public function testSubmitRemoteExecutionWithMissingExecutionIdQueryParam()
     {
         $this->expectException(RuntimeException::class);


### PR DESCRIPTION
# [TR-5528](https://oat-sa.atlassian.net/browse/TR-5528)

## Summary
This PR aim to provide new endpoint available as exit url in scope of lti 1p3 launch which should finalise state of executions

## How to test
- checkout or install as dev dependency this branch over configured as TAO3.x backoffice
- launch remote delivery via TAO3.x
- after execution browser should be redirect on new endpoint and after that in page with available for launches deliveries
- available for resume executions shouldn't appear

feature avalaible on - https://lti1p3-platform.playground.kitchen.it.taocloud.org/
for full validation expecting fe deployment - https://github.com/oat-sa/taocloud-gitops/pull/1666

## Depends on 
https://github.com/oat-sa/tao-deliver-fe/pull/774



## TODO
- [x] test case

[TR-5528]: https://oat-sa.atlassian.net/browse/TR-5528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ