### PR TITLE
fix: align lti consumer delivery-new tree action weight

### DIFF
--- a/controller/structures.xml
+++ b/controller/structures.xml
@@ -5,7 +5,7 @@
         <sections>
             <section id="manage_delivery_assembly" name="Deliveries" url="/taoDeliveryRdf/DeliveryMgmt/index">
                 <actions >
-                    <action id="delivery-new" name="New delivery" url="/taoLtiConsumer/DeliveryMgmt/wizard" context="resource" group="tree" weight="1">
+                    <action id="delivery-new" name="New delivery" url="/taoLtiConsumer/DeliveryMgmt/wizard" context="resource" group="tree" weight="7">
                         <icon id="icon-delivery"/>
                     </action>
                 </actions>


### PR DESCRIPTION
## Summary
- adjust `delivery-new` tree action weight in LTI Consumer to keep delivery tree ordering stable with Quick Wins sorting

## Validation
- cleared cache with `rm -Rf data/generis/cache/*`
- verified merged delivery tree order in runtime checks


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the display priority of the delivery creation feature within the delivery management interface, affecting its position in the UI.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/oat-sa/extension-tao-lti-consumer/pull/92)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->